### PR TITLE
[WIP] Fix Union with DateTime JSON conversion 

### DIFF
--- a/Fable.Remoting.Json.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.Json.Tests/FableConverterTests.fs
@@ -37,7 +37,7 @@ let converterTest =
             | otherwise -> fail()
 
         testCase "Union with DateTime conversion" <| fun () ->  
-            let dateInput = DateTime.Now
+            let dateInput = DateTime.Now.ToUniversalTime()
             let serialized = serialize (UnionWithDateTime.Date dateInput) 
             let deserialized = deserialize<UnionWithDateTime> serialized 
             match deserialized with 

--- a/Fable.Remoting.Json.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.Json.Tests/FableConverterTests.fs
@@ -35,7 +35,21 @@ let converterTest =
             match deserialized with
             | Some "value" -> pass()
             | otherwise -> fail()
-   
+
+        testCase "Union with DateTime conversion" <| fun () ->  
+            let dateInput = DateTime.Now
+            let serialized = serialize (UnionWithDateTime.Date dateInput) 
+            let deserialized = deserialize<UnionWithDateTime> serialized 
+            match deserialized with 
+            | Int _ -> fail() 
+            | Date dateOutput ->
+                Expect.equal dateInput.Second dateOutput.Second "Seconds are the same"
+                Expect.equal dateInput.Minute dateOutput.Minute "Minutes are the same" 
+                Expect.equal dateInput.Hour dateOutput.Hour "Hours are the same" 
+                Expect.equal dateInput.Day dateOutput.Day "Days are the same" 
+                Expect.equal dateInput.Month dateOutput.Month "Months are the same" 
+                Expect.equal dateInput.Year dateOutput.Year "Year are the same" 
+                Expect.equal dateInput.Kind dateOutput.Kind "Kinds are the same"
 
         testCase "Single case union is deserialized correctly" <| fun () ->
           // assert that deserialization works

--- a/Fable.Remoting.Json.Tests/Types.fs
+++ b/Fable.Remoting.Json.Tests/Types.fs
@@ -1,5 +1,7 @@
 ﻿module Types
 
+open System 
+
 type Record = { 
     Prop1 : string
     Prop2 : int
@@ -9,6 +11,10 @@ type Record = {
 type Maybe<'t> = 
     | Just of 't
     | Nothing
+
+type UnionWithDateTime = 
+    | Date of DateTime
+    | Int of int
 
 type AB = A | B
 


### PR DESCRIPTION
This type:
```fs
type UnionWithDateTime = 
    | Date of DateTime
    | Int of int
```
fails this test:
```fs
testCase "Union with DateTime conversion" <| fun () ->  
    let dateInput = DateTime.Now
    let serialized = serialize (UnionWithDateTime.Date dateInput) 
    let deserialized = deserialize<UnionWithDateTime> serialized 
    match deserialized with 
    | Int _ -> fail() 
    | Date dateOutput ->
        Expect.equal dateInput.Second dateOutput.Second "Seconds are the same"
        Expect.equal dateInput.Minute dateOutput.Minute "Minutes are the same" 
        Expect.equal dateInput.Hour dateOutput.Hour "Hours are the same" 
        Expect.equal dateInput.Day dateOutput.Day "Days are the same" 
        Expect.equal dateInput.Month dateOutput.Month "Months are the same" 
        Expect.equal dateInput.Year dateOutput.Year "Year are the same" 
        Expect.equal dateInput.Kind dateOutput.Kind "Kinds are the same"
```
with message:
```fs
Converter Tests/Union with DateTime conversion failed in 00:00:00.7470000.
Hours are the same. Actual value was 23 but had expected it to be 21.
```