### PR TITLE
Self-contained tests for dotnet client added to CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
  - travis_wait dotnet run -p Fable.Remoting.Suave.Tests/Fable.Remoting.Suave.Tests.fsproj
  - travis_wait dotnet run -p Fable.Remoting.Giraffe.Tests/Fable.Remoting.Giraffe.Tests.fsproj
  - travis_wait ./build.sh IntegrationTests
+ - travis_wait ./build.sh RunDotnetClientTests

--- a/Fable.Remoting.IntegrationTests/DotnetClient/DotnetClient.fsproj
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/DotnetClient.fsproj
@@ -7,11 +7,13 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\SharedTypes.fs" />
+    <Compile Include="..\Shared\ServerImpl.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj" />
+    <ProjectReference Include="../../Fable.Remoting.Suave/Fable.Remoting.Suave.fsproj" />   
   </ItemGroup>
 
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -200,12 +200,12 @@ let dotnetClientTests =
         }
 
         // Inline values cannot always be compiled, so define first and reference from inside the quotation expression
-        //testCaseAsync "IServer.echoNestedGeneric inline in expression" <| async { 
-        //    let! result1 = proxy.call <@ fun server -> server.echoNestedGeneric { Value = Just (Some 5); OtherValue = 2 }  @>
-        //    let! result2 = proxy.call <@ fun server -> server.echoNestedGeneric { Value = Just (None); OtherValue = 2 } @>
-        //    Expect.equal true ({ Value = Just (Some 5); OtherValue = 2 } = result1) "Nested generic record is correct"
-        //    Expect.equal true ({ Value = Just (None); OtherValue = 2 } = result2) "Nested generic record is correct"
-        //}
+        testCaseAsync "IServer.echoNestedGeneric inline in expression" <| async { 
+            let! result1 = proxy.call <@ fun server -> server.echoNestedGeneric { Value = Just (Some 5); OtherValue = 2 }  @>
+            let! result2 = proxy.call <@ fun server -> server.echoNestedGeneric { Value = Just (None); OtherValue = 2 } @>
+            Expect.equal true ({ Value = Just (Some 5); OtherValue = 2 } = result1) "Nested generic record is correct"
+            Expect.equal true ({ Value = Just (None); OtherValue = 2 } = result2) "Nested generic record is correct"
+        }
 
         testCaseAsync "IServer.echoIntList" <| async {
             let inputList = [1 .. 5]

--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -2,11 +2,70 @@
 
 open System
 open SharedTypes
+open Fable.Remoting.Server
+open Fable.Remoting.Suave
 open Fable.Remoting.DotnetClient 
 open Expecto
 open Expecto.Logging
+open Suave
+open Suave.Files
+open Suave.Operators
+open Suave.Filters
+open ServerImpl
+open System.Threading
 
-let proxy = Proxy.create<IServer> (sprintf "http://localhost:8080/api/%s/%s")
+let fableWebPart = remoting server {
+    use_route_builder routeBuilder
+    use_error_handler (fun ex routeInfo ->
+      printfn "Error at: %A" routeInfo
+      Propagate ex.Message)
+    use_custom_handler_for "overriddenFunction" (fun _ -> ResponseOverride.Default.withBody "42" |> Some)
+    use_custom_handler_for "customStatusCode" (fun _ -> ResponseOverride.Default.withStatusCode 204 |> Some)
+}
+
+let isVersion v (ctx:HttpContext) =
+  if ctx.request.headers |> List.contains ("version",v) then
+    None
+  else
+    Some {ResponseOverride.Default with Abort = true}
+let versionTestWebPart =
+  remoting versionTestServer {
+    use_route_builder versionTestBuilder
+    use_custom_handler_for "v4" (isVersion "4")
+    use_custom_handler_for "v3" (isVersion "3")
+    use_custom_handler_for "v2" (isVersion "2")
+  }
+
+let contextTestWebApp =
+    remoting {callWithCtx = fun (ctx:HttpContext) -> async{return ctx.request.path}} {
+        use_route_builder routeBuilder
+    }
+
+let webApp = 
+  choose [ GET >=> browseHome
+           fableWebPart 
+           versionTestWebPart
+           contextTestWebApp  ]
+
+let cts = new CancellationTokenSource() 
+let suaveConfig = 
+    { defaultConfig with
+        bindings   = [ HttpBinding.createSimple HTTP "127.0.0.1" 9090 ]
+        bufferSize = 2048
+        cancellationToken = cts.Token }
+
+let listening, server = startWebServerAsync suaveConfig webApp
+Async.Start server 
+printfn "Web server started"
+printfn "Getting server ready to listen for reqeusts"
+listening
+|> Async.RunSynchronously
+|> ignore
+printfn "Server listening to requests"
+
+
+let proxy = Proxy.create<IServer> (sprintf "http://localhost:9090/api/%s/%s")
+
 let dotnetClientTests = 
     testList "Dotnet Client tests" [
 
@@ -248,7 +307,7 @@ let dotnetClientTests =
         }
 
         testCaseAsync "IContextTest.test" <| async {
-            let routes = sprintf "http://localhost:8080/api/%s/%s" 
+            let routes = sprintf "http://localhost:9090/api/%s/%s" 
             let contextProxy = Proxy.create<IContextTest<unit>> routes
             let! result = contextProxy.call <@ fun server -> server.callWithCtx() @>
             Expect.equal result "/api/IContextTest/callWithCtx" "Result from contextual proxy is correct"
@@ -260,4 +319,8 @@ let testConfig =  { Expecto.Tests.defaultConfig with
                         verbosity = LogLevel.Debug }
                         
 [<EntryPoint>]
-let main argv = runTests testConfig dotnetClientTests
+let main argv = 
+    let testResult = runTests testConfig dotnetClientTests
+    // quit server
+    cts.Cancel()
+    testResult

--- a/Fable.Remoting.IntegrationTests/DotnetClient/paket.references
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/paket.references
@@ -1,2 +1,3 @@
 FSharp.Core
 Expecto
+Suave

--- a/build.fsx
+++ b/build.fsx
@@ -92,8 +92,10 @@ Target "BuildDotnetClientTests" <| fun _ ->
     run (getPath "IntegrationTests" </> "DotnetClient") "dotnet" "build"
 
 Target "RunDotnetClientTests" <| fun _ ->
-    clean (getPath "IntegrationTests" </> "DotnetClient")
-    run (getPath "IntegrationTests" </> "DotnetClient") "dotnet" "run"
+    let path = getPath "IntegrationTests" </> "DotnetClient"
+    clean path
+    run path "dotnet" "restore --no-cache"
+    run path "dotnet" "run"
 
 Target "BuildRunServerTests" <| fun _ ->
     run "." "dotnet" ("build " + proj "Server.Tests" + " --configuration=Release")


### PR DESCRIPTION
Build target `RunDotnetClientTests` now spins up a suave server and runs the dotnet client tests in one pass