### PR TITLE
C*#* and F*#* typo?

### DIFF
--- a/documentation/src/dotnet-csharp.md
+++ b/documentation/src/dotnet-csharp.md
@@ -1,6 +1,6 @@
-# Using .NET client from C*#*
+# Using .NET client from C#
 
-The .NET client can also be used with C# in an idiomatic way. You will need to put the protocol definitions inside a F*#* project and reference the project in a C*#* project to have the types available from your C*#* application:
+The .NET client can also be used with C# in an idiomatic way. You will need to put the protocol definitions inside a F# project and reference the project in a C# project to have the types available from your C# application:
 ```cs
 using System;
 using System.Threading.Tasks;  


### PR DESCRIPTION
Github renders as `C*#*` and `F*#*` (with the stars). Not 100% sure about this, because looks good on the docs site...
![image](https://user-images.githubusercontent.com/844331/43646511-60ee347a-9735-11e8-8122-b70cada07066.png)
