### PR TITLE
Fixed combineRouteWithBaseUrl

### DIFF
--- a/Fable.Remoting.Client/Proxy.fs
+++ b/Fable.Remoting.Client/Proxy.fs
@@ -68,10 +68,7 @@ module Proxy =
     let combineRouteWithBaseUrl route (baseUrl: string option) = 
         match baseUrl with
         | None -> route
-        | Some url -> 
-            if url.EndsWith("/")
-            then sprintf "%s%s" url route
-            else sprintf "%s/%s" url route
+        | Some url -> sprintf "%s%s" (url.TrimEnd('/')) route
 
     /// Extracts the 'T from Async<'T>
     let extractAsyncArg (asyncType: Type) = 

--- a/Fable.Remoting.ClientV2/Proxy.fs
+++ b/Fable.Remoting.ClientV2/Proxy.fs
@@ -29,10 +29,7 @@ module Proxy =
     let combineRouteWithBaseUrl route (baseUrl: string option) = 
         match baseUrl with
         | None -> route
-        | Some url -> 
-            if url.EndsWith("/")
-            then sprintf "%s%s" url route
-            else sprintf "%s/%s" url route
+        | Some url -> sprintf "%s%s" (url.TrimEnd('/')) route
 
     [<Emit("arguments")>]
     let arguments() : obj[] = jsNative


### PR DESCRIPTION
Since `route` always starts with `/` according to `RouteBuilder = sprintf ("/%s/%s")`, `combineRouteWithBaseUrl` always resulted with a final url like `http://baseurl//IMusicStore/allAlbums`.
This fix avoids duplicated slash.