### PR TITLE
Ensure HttpOnly Cookies are round-tripped

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -445,3 +445,23 @@ QUnit.testCaseAsync "IServer.tuplesAndLists" <| fun test ->
         let expected = Map.ofList [ "hello", 5; "there!", 6 ] 
         test.equal true (expected = outputDict)  
     }
+
+let cookieServer =
+    Remoting.createApi()
+    |> Remoting.withRouteBuilder routeBuilder
+    |> Remoting.buildProxy<ICookieServer>
+
+QUnit.testCaseAsync "ICookieServer.checkCookie" <| fun test ->
+    async {
+        // Cookie not set yet
+        let! firstCall = cookieServer.checkCookie ()
+        test.equalWithMsg false firstCall "Cookie should not be set yet"
+
+        // Cookie should now be set and sent back to server
+        let! secondCall = cookieServer.checkCookie ()
+        test.equalWithMsg true secondCall "Cookie should have been set and sent"
+
+        // Cookie should not be visible to javascript (HttpOnly)
+        let notInJs = Fable.Import.Browser.document.cookie = ""
+        test.equalWithMsg true notInJs "Cookie should not be visible to javascript"
+    }

--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -462,6 +462,6 @@ QUnit.testCaseAsync "ICookieServer.checkCookie" <| fun test ->
         test.equalWithMsg true secondCall "Cookie should have been set and sent"
 
         // Cookie should not be visible to javascript (HttpOnly)
-        let notInJs = Fable.Import.Browser.document.cookie = ""
+        let notInJs = Fable.Import.Browser.document.cookie.Contains("httpOnly-test-cookie") = false
         test.equalWithMsg true notInJs "Cookie should not be visible to javascript"
     }

--- a/Fable.Remoting.IntegrationTests/Client/App.fs
+++ b/Fable.Remoting.IntegrationTests/Client/App.fs
@@ -372,3 +372,23 @@ QUnit.testCaseAsync "IServer.tuplesAndLists" <| fun test ->
         let expected = Map.ofList [ "hello", 5; "there!", 6 ] 
         test.equal true (expected = outputDict)  
     }
+
+let cookieServer =
+    Remoting.createApi()
+    |> Remoting.withRouteBuilder routeBuilder
+    |> Remoting.buildProxy<ICookieServer>
+
+QUnit.testCaseAsync "ICookieServer.checkCookie" <| fun test ->
+    async {
+        // Cookie not set yet
+        let! firstCall = cookieServer.checkCookie ()
+        test.equalWithMsg false firstCall "Cookie should not be set yet"
+
+        // Cookie should now be set and sent back to server
+        let! secondCall = cookieServer.checkCookie ()
+        test.equalWithMsg true secondCall "Cookie should have been set and sent"
+
+        // Cookie should not be visible to javascript (HttpOnly)
+        let notInJs = Fable.Import.Browser.document.cookie = ""
+        test.equalWithMsg true notInJs "Cookie should not be visible to javascript"
+    }

--- a/Fable.Remoting.IntegrationTests/Client/App.fs
+++ b/Fable.Remoting.IntegrationTests/Client/App.fs
@@ -389,6 +389,6 @@ QUnit.testCaseAsync "ICookieServer.checkCookie" <| fun test ->
         test.equalWithMsg true secondCall "Cookie should have been set and sent"
 
         // Cookie should not be visible to javascript (HttpOnly)
-        let notInJs = Fable.Import.Browser.document.cookie = ""
+        let notInJs = Fable.Import.Browser.document.cookie.Contains("httpOnly-test-cookie") = false
         test.equalWithMsg true notInJs "Cookie should not be visible to javascript"
     }

--- a/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
@@ -12,6 +12,10 @@ let simpleServer : ISimpleServer = {
     getLength = fun input -> Async.result input.Length
 }
 
+let cookieServer readCookie : ICookieServer = {
+    checkCookie = fun () -> readCookie () |> Async.result
+}
+
 // Async.result : 'a -> Async<'a>
 // a simple implementation, just return whatever value you get (echo the input)
 let server : IServer  = {

--- a/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
@@ -30,6 +30,10 @@ type ISimpleServer = {
     getLength : string -> Async<int>
 }
 
+type ICookieServer = {
+    checkCookie : unit -> Async<bool>
+}
+
 type RecursiveRecord = {
     Name: string
     Children : RecursiveRecord list


### PR DESCRIPTION
Adds integration tests to ensure that ``HttpOnly`` cookies are correctly handled.

I wasn't sure how best to fit these tests in your system, so if you want it done differently, let me know. I tried to keep them isolated while still following your design.