### PR TITLE
Add resolve function for Authorization header

### DIFF
--- a/Fable.Remoting.Client/Proxy.fs
+++ b/Fable.Remoting.Client/Proxy.fs
@@ -96,14 +96,13 @@ module Proxy =
                        Cookie Fable.Import.Browser.document.cookie ]
 
                 let headers =
-                  [ match options.Authorization with 
-                    | Some authToken -> 
-                      yield Authorization authToken 
-                      yield! defaultHeaders
-                      yield! options.CustomHeaders
-                    | None -> 
-                      yield! defaultHeaders
-                      yield! options.CustomHeaders  ] 
+                  [ yield! defaultHeaders
+                    yield! options.CustomHeaders
+
+                    match options.AuthorizationResolve, options.Authorization with 
+                    | Some resolveFun, _ -> yield Authorization (resolveFun())
+                    | None, Some authToken -> yield Authorization authToken 
+                    | _ -> () ]
 
                 // Send RPC request to the server
                 let requestProps = [

--- a/Fable.Remoting.Client/Remoting.fs
+++ b/Fable.Remoting.Client/Remoting.fs
@@ -8,6 +8,7 @@ module Remoting =
         CustomHeaders = [ ]
         BaseUrl = None
         Authorization = None
+        AuthorizationResolve = None
         RouteBuilder = sprintf ("/%s/%s") 
     }
     
@@ -27,6 +28,10 @@ module Remoting =
     let withAuthorizationHeader token (options: RemoteBuilderOptions) = 
         { options with Authorization = Some token }
  
+    /// Sets the resolve function for authorization header of every request from the proxy
+    let withAuthorizationHeaderResolver resolveFun (options: RemoteBuilderOptions) =
+        { options with AuthorizationResolve = Some resolveFun }
+
     [<PassGenerics>]
     let buildProxy<'t> (options: RemoteBuilderOptions) : 't = 
         // create an empty object literal

--- a/Fable.Remoting.Client/Types.fs
+++ b/Fable.Remoting.Client/Types.fs
@@ -24,6 +24,7 @@ type RemoteBuilderOptions = {
        CustomHeaders : HttpRequestHeaders list
        BaseUrl  : string option
        Authorization : string option
+       AuthorizationResolve : (unit -> string) option
        RouteBuilder : (string -> string -> string)
 }
 

--- a/Fable.Remoting.ClientV2/Proxy.fs
+++ b/Fable.Remoting.ClientV2/Proxy.fs
@@ -71,9 +71,10 @@ module Proxy =
                   [ yield "Content-Type", "application/json; charset=utf8"
                     yield! options.CustomHeaders
                     
-                    match options.Authorization with 
-                    | Some authToken -> yield "Authorization", authToken
-                    | None -> () ]
+                    match options.AuthorizationResolve, options.Authorization with 
+                    | Some resolveFun, _ -> yield "Authorization", (resolveFun())
+                    | None, Some authToken -> yield "Authorization", authToken
+                    | _ -> () ]
 
 
                 let! response = 

--- a/Fable.Remoting.ClientV2/Remoting.fs
+++ b/Fable.Remoting.ClientV2/Remoting.fs
@@ -9,6 +9,7 @@ module Remoting =
         CustomHeaders = [ ]
         BaseUrl = None
         Authorization = None
+        AuthorizationResolve = None
         RouteBuilder = sprintf ("/%s/%s") 
     }
     
@@ -27,6 +28,10 @@ module Remoting =
     /// Sets the authorization header of every request from the proxy
     let withAuthorizationHeader token (options: RemoteBuilderOptions) = 
         { options with Authorization = Some token }
+
+    /// Sets the resolve function for authorization header of every request from the proxy
+    let withAuthorizationHeaderResolver resolveFun (options: RemoteBuilderOptions) =
+        { options with AuthorizationResolve = Some resolveFun }
 
 type Remoting() = 
     static member buildProxy<'t>(options: RemoteBuilderOptions, [<Inject>] ?resolver: ITypeResolver<'t>) : 't = 

--- a/Fable.Remoting.ClientV2/Types.fs
+++ b/Fable.Remoting.ClientV2/Types.fs
@@ -18,6 +18,7 @@ type RemoteBuilderOptions = {
     CustomHeaders : (string * string) list
     BaseUrl  : string option
     Authorization : string option
+    AuthorizationResolve : (unit -> string) option
     RouteBuilder : (string -> string -> string)
 }
 


### PR DESCRIPTION
I know that the recommended way for authentication/authorization in Fable.Remoting is to pass a token explicitly as a function argument. However after my talk about Fable.Remoting I got a lot of questions regarding this topic. So I decided that this functionality will be quite useful.

Currently you can add an Authorization header with `Remoting.withAuthorizationHeader`, but since it happens only once, the header must be constant. I added `Remoting.withAuthorizationHeaderResolver` function, which expects a function of type `unit -> string` to resolve the header on each request. This allows to get and apply the token dynamically with an ability to refresh it.