### PR TITLE
Fixes DateTimeOffset raw deserialization issue

### DIFF
--- a/Fable.Remoting.AspNetCore/Fable.Remoting.AspNetCore.fsproj
+++ b/Fable.Remoting.AspNetCore/Fable.Remoting.AspNetCore.fsproj
@@ -8,7 +8,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;remoting;rpc;webserver;aspnet</PackageTags>
     <Authors>Zaid Ajaj;Diego Esmerio</Authors>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Fable.Remoting.Giraffe/Fable.Remoting.Giraffe.fsproj
+++ b/Fable.Remoting.Giraffe/Fable.Remoting.Giraffe.fsproj
@@ -8,7 +8,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;remoting;rpc;webserver;giraffe</PackageTags>
     <Authors>Zaid Ajaj;Diego Esmerio</Authors>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/Fable.Remoting.Json.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.Json.Tests/FableConverterTests.fs
@@ -6,6 +6,7 @@ open System
 open Fable.Remoting.Json
 open Expecto
 open Types
+open Expecto.Logging
 
 let converter = new FableJsonConverter()
 let deserialize<'a> (json : string) = 
@@ -152,6 +153,17 @@ let converterTest =
             match Map.toList deserialized with
             | ["one", Some 1; "two", Some 2] -> pass()
             | otherwise -> fail()
+
+        testCase "DateTimeOffset can be deserialized" <| fun () -> 
+            let input = "\"2019-04-01T16:00:00.000+05:00\""
+            let deserialized = deserialize<DateTimeOffset> input
+            let parsed = DateTimeOffset.Parse "2019-04-01T16:00:00.000+05:00"
+            Expect.equal (deserialized.ToString()) (parsed.ToString()) "offsets should be the same"
+
+        testCase "DateTimeOffset can be serialized correctly" <| fun () -> 
+            let value = DateTimeOffset.Parse "2019-04-01T16:00:00.000+05:00"
+            let roundtripped = deserialize<DateTimeOffset> (serialize value) 
+            Expect.equal value roundtripped "offsets should be the same"
 
         testCase "Generic union types deserialization from raw json works" <| fun () -> 
             // toJson (Just 5) = "{\"Just\":5}"

--- a/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
+++ b/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
@@ -8,7 +8,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;remoting;rpc;webserver</PackageTags>
     <Authors>Zaid Ajaj;Diego Esmerio</Authors>
-    <Version>4.4.0</Version>
+    <Version>4.4.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>

--- a/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
+++ b/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
@@ -26,6 +26,7 @@ let errorHandler (ex: exn) (_: RouteInfo<_>) =
 let app = 
   Remoting.createApi()
   |> Remoting.fromValue implementation  
+  |> Remoting.withDiagnosticsLogger (printfn "%s")
   |> Remoting.withErrorHandler errorHandler 
   |> Remoting.buildWebPart
 
@@ -60,7 +61,20 @@ let fableSuaveAdapterTests =
             |> req POST "/IProtocol/echoInteger" (Some input)
             |> fun result -> equal "10" result
 
-    
+        testCase "DateTimeOffset roundtrip" <| fun () -> 
+            let defaultConfig = getConfig()
+            let input = postContent "\"2019-04-01T16:00:00+05:00\""
+            runWith defaultConfig app 
+            |> req POST "/IProtocol/datetimeOffset" (Some input)
+            |> fun result -> equal "\"2019-04-01T16:00:00+05:00\"" result
+
+        testCase "Maybe<DateTimeOffset> roundtrip" <| fun () -> 
+            let defaultConfig = getConfig()
+            let input = postContent "{\"Just\":\"2019-04-01T16:00:00+05:00\"}"
+            runWith defaultConfig app 
+            |> req POST "/IProtocol/maybeDatetimeOffset" (Some input)
+            |> fun result -> equal "{\"Just\":\"2019-04-01T16:00:00+05:00\"}" result
+
         testCase "Sending some option as input works" <| fun () ->
             let defaultConfig = getConfig ()
             let someInput = postContent "5" // toJson (Some 5) => "5"

--- a/Fable.Remoting.Suave.Tests/Types.fs
+++ b/Fable.Remoting.Suave.Tests/Types.fs
@@ -1,6 +1,7 @@
 ﻿module Types
 
 open System
+open System
 
 type Record = { 
     Prop1 : string
@@ -39,6 +40,8 @@ type IProtocol = {
     multipleSum : int -> int -> Async<int>
     lotsOfArgs : string -> int -> float -> Async<string>
     echoSingleDULong : SingleLongCase -> Async<SingleLongCase>
+    datetimeOffset : DateTimeOffset -> Async<DateTimeOffset>
+    maybeDatetimeOffset : Maybe<DateTimeOffset> -> Async<Maybe<DateTimeOffset>>
 }
 
 let implementation = {
@@ -70,4 +73,6 @@ let implementation = {
     multipleSum = fun a b -> async {return a + b}
     lotsOfArgs = fun s i f -> async {return sprintf "string: %s; int: %i; float: %f" s i f}
     echoSingleDULong = fun x -> async { return x } 
- }
+    datetimeOffset = fun x -> async { return x }
+    maybeDatetimeOffset = fun x -> async { return x }
+}

--- a/Fable.Remoting.Suave/Fable.Remoting.Suave.fsproj
+++ b/Fable.Remoting.Suave/Fable.Remoting.Suave.fsproj
@@ -8,7 +8,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;remoting;rpc;webserver;suave</PackageTags>
     <Authors>Zaid Ajaj;Diego Esmerio</Authors>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
Address #109 
Ok so this was a bit [dump](https://github.com/JamesNK/Newtonsoft.Json/issues/862) on the Newtonsoft.Json side of things, parsing raw strings get interpreted as dates if they look like dates and this is a default behaviour 😱 
```fs
let json = "[ \"2019-04-01T16:00:00+05:00\" ]"
let parsed = JToken.Parse(json)
parsed.ToString() // [ "2019-04-01T16:00:00+02:00"] 
```
Luckily this can be overridden:
```fs
let json = "[ \"2019-04-01T16:00:00+05:00\" ]"
let settings = JsonSerializerSettings(DateParseHandling = DateParseHandling.None)
let parsed = JsonConvert.DeserializeObject<JToken>(json, settings) 
```
