### PR TITLE
Documentation updates - removed reference to deprecated Saturn function and tweaked suggested webpack "devServerProxy" config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ let webApp : HttpHandler =
 
 let app = application {
     url "http://127.0.0.1:8083/"
-    router webApp
+    use_router webApp
 }
 
 run app

--- a/documentation/src/client.md
+++ b/documentation/src/client.md
@@ -44,7 +44,7 @@ devServer: {
   // tell webpack-dev-server to re-route all requests 
   // from dev-server to the actual server
   proxy: {
-    '/*': { 
+    '/**': { 
       // assuming the suave server is running on port 8083
       target: "http://localhost:8083",
       changeOrigin: true

--- a/documentation/src/dependency-injection.md
+++ b/documentation/src/dependency-injection.md
@@ -72,7 +72,7 @@ let configureServices (services : IServiceCollection) =
     services.AddSingleton<ITodoStore, InMemoryTodoStore>()
 
 application {
-    router webApp
+    use_router webApp
     service_config configureServices
     // other config options
 }

--- a/documentation/src/saturn.md
+++ b/documentation/src/saturn.md
@@ -30,7 +30,7 @@ let webApp : HttpHandler =
 
 let app = application {
     url "http://127.0.0.1:8083/"
-    router webApp
+    use_router webApp
 }
 
 run app


### PR DESCRIPTION
- Updated `saturn.md`, `README.md` and `dependency-injection.md` to reference `use_router` rather than the deprecated `router`.
- Updated `client.md` to use what I believe is the correct syntax to help avoid http-proxy-middleware (https://github.com/chimurai/http-proxy-middleware) error.