### PR TITLE
performance: add a cache for UnionCaseInfo

### DIFF
--- a/Fable.Remoting.Json/FableConverter.fs
+++ b/Fable.Remoting.Json/FableConverter.fs
@@ -102,6 +102,7 @@ type MapStringKeySerializer<'v>() =
 module private Cache =
     let jsonConverterTypes = ConcurrentDictionary<Type,Kind>()
     let serializationBinderTypes = ConcurrentDictionary<string,Type>()
+    let unionCaseInfoCache = ConcurrentDictionary<Type,string*PropertyInfo array>()
 
 open Cache
 open Newtonsoft.Json.Linq
@@ -144,7 +145,6 @@ type FableJsonConverter() =
         FSharpType.GetUnionCases(t)
         |> Array.find (fun uci -> uci.Name = name)
 
-    let unionCaseInfoCache = Dictionary<Type,string*PropertyInfo array>()
 
     let getUnionCaseNameAndFields value t =
         match unionCaseInfoCache.TryGetValue t with


### PR DESCRIPTION
closes https://github.com/Zaid-Ajaj/Fable.Remoting/issues/127

based on https://github.com/0x53A/FableRemotingSerializationTest/commit/a28e01203a518164367769ef4b4983c741ceb743

![image](https://user-images.githubusercontent.com/4236651/62224148-821eff00-b3b6-11e9-89be-9d9a52f39837.png)

__Question:__ Is using just a Dictionary safe, or could the instance be shared between Threads?

Edit: Answer: one instance is shared, so need to use ConcurrentDictionary