### PR TITLE
Remove redundant target frameworks

### DIFF
--- a/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
+++ b/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
@@ -8,7 +8,7 @@
         <PackageTags>fsharp;fable;remoting;rpc;webserver;json</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>3.5.0</Version>
-        <TargetFrameworks>net45; net461; netstandard2.0; netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>

--- a/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
+++ b/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
@@ -23,11 +23,6 @@
         <Reference Include="System.Threading.Tasks" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Threading.Tasks" />
-    </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\Fable.Remoting.Json\Fable.Remoting.Json.fsproj" />
         <ProjectReference Include="..\Fable.Remoting.MsgPack\Fable.Remoting.MsgPack.fsproj" />

--- a/Fable.Remoting.Giraffe/Fable.Remoting.Giraffe.fsproj
+++ b/Fable.Remoting.Giraffe/Fable.Remoting.Giraffe.fsproj
@@ -9,7 +9,7 @@
         <PackageTags>fsharp;fable;remoting;rpc;webserver;giraffe</PackageTags>
         <Authors>Zaid Ajaj;Diego Esmerio</Authors>
         <Version>4.5.0</Version>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 

--- a/Fable.Remoting.Json/Fable.Remoting.Json.fsproj
+++ b/Fable.Remoting.Json/Fable.Remoting.Json.fsproj
@@ -9,7 +9,7 @@
         <PackageTags>fsharp;fable;remoting;rpc;webserver;json</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>2.10.0</Version>
-        <TargetFrameworks>netstandard2.0;net45;net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
+++ b/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
@@ -11,7 +11,7 @@
     <Version>1.4.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Optimize reflection and allocation by using TypeShape</PackageReleaseNotes>
-    <TargetFrameworks>netstandard2.0;net45;net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>NET_CORE</DefineConstants>

--- a/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
+++ b/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
@@ -10,7 +10,7 @@
         <Authors>Zaid Ajaj;Diego Esmerio</Authors>
         <Version>5.5.0</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFrameworks>netstandard2.0;net462;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/Fable.Remoting.Suave/Fable.Remoting.Suave.fsproj
+++ b/Fable.Remoting.Suave/Fable.Remoting.Suave.fsproj
@@ -10,7 +10,7 @@
         <Authors>Zaid Ajaj;Diego Esmerio</Authors>
         <Version>4.5.0</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Targetting `net462` on top of `net45` is unnecessary because the latter can be used in any application compiled against .NET 4.5 through 4.8.
Targetting `netcoreapp3.1` on top of `netstandard2.0` is unnecessary for the same reason on .NET Core as well as the fact that they don't have a different set of dependencies either (like [this](https://www.nuget.org/packages/Giraffe/4.1.0) where `netcoreapp3.0` drops obsolete ASP.NET packages, symplifying dependency graphs and lock files in .NET Core 3.0+ applications). The only exception here is the MsgPack project, which [conditionally relies](https://github.com/Zaid-Ajaj/Fable.Remoting/blob/3f8e2733bcee99e938bd67300bc50ae9a411d392/Fable.Remoting.MsgPack/Write.fs#L167-L193) on specific .NET Core APIs.

The result of this change are slightly faster builds and slightly smaller Nuget packages.