### PR TITLE
Optimize request proxying

### DIFF
--- a/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
+++ b/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
@@ -40,7 +40,6 @@ let invoke<'out, 'impl> (funcName: string) (record: 'impl) (input: Choice<obj[],
 
     let proxy = makeApiProxy options
     use inp = new MemoryStream ()
-    use out = new MemoryStream ()
 
     let inputBytes =
         match input with
@@ -49,8 +48,8 @@ let invoke<'out, 'impl> (funcName: string) (record: 'impl) (input: Choice<obj[],
     inp.Write (inputBytes, 0, inputBytes.Length)
     inp.Position <- 0L
 
-    match proxy { Implementation = record; Input = inp; Output = out; EndpointName = funcName; HttpVerb = "POST"; IsContentBinaryEncoded = false; IsProxyHeaderPresent = true } |> Async.RunSynchronously with
-    | Success _ -> JsonConvert.DeserializeObject<'out>(System.Text.Encoding.UTF8.GetString (out.ToArray ()), converter)
+    match proxy { Implementation = record; Input = inp; EndpointName = funcName; HttpVerb = "POST"; IsContentBinaryEncoded = false; IsProxyHeaderPresent = true } |> Async.RunSynchronously with
+    | Success (_, output) -> JsonConvert.DeserializeObject<'out>(System.Text.Encoding.UTF8.GetString (output.ToArray ()), converter)
     | InvocationResult.Exception (e, _) -> raise e
     | InvalidHttpVerb -> failwithf "Function %s does not expect POST" funcName
     | EndpointNotFound -> failwithf "Function %s was not found" funcName

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -56,7 +56,6 @@ type ShapeFSharpAsync<'T> () =
 type InvocationPropsInt = {
     Arguments: Choice<byte[], JToken list>
     ArgumentCount: int
-    Output: Stream
     IsProxyHeaderPresent: bool
 }
 
@@ -65,7 +64,6 @@ type InvocationProps<'impl> = {
     Implementation: 'impl
     EndpointName: string
     HttpVerb: string
-    Output: Stream
     IsContentBinaryEncoded: bool
     IsProxyHeaderPresent: bool
 }
@@ -78,7 +76,7 @@ type MakeEndpointProps = {
 }
 
 type InvocationResult =
-    | Success of isBinaryOutput: bool
+    | Success of isBinaryOutput: bool * output: MemoryStream
     | EndpointNotFound
     | InvalidHttpVerb
     | Exception of exn * functionName: string


### PR DESCRIPTION
- Don't recreate a proxy with TypeShape for every request 🤦‍♂️
- Consider using multiple remoting APIs such as
  ```fsharp
  .UseGiraffe (choose [ deckApiHandler; accountApiHandler; learnApiHandler; otherApiHandler; statsApiHandler ])
  ```
  For `statsApiHandler` requests, implementations for the first 4 handlers would be unnecessarily created if `FromContext` is used, which could be wasteful if those have expensive dependencies. A new `MemoryStream` would be allocated for each of the 4 too, regardless of the fact whether routes match or not.