### PR TITLE
Add dotnet client remoting without quotations

### DIFF
--- a/Fable.Remoting.DotnetClient/ClientRemoting.fs
+++ b/Fable.Remoting.DotnetClient/ClientRemoting.fs
@@ -127,7 +127,9 @@ module ClientRemoting =
         | Some token -> client.DefaultRequestHeaders.Add("Authorization", token)
         | _ -> ()
 
-        let ctor = t.GetConstructors() |> Seq.exactlyOne
+        match t.GetConstructors() |> Seq.tryExactlyOne with
+        | None -> failwith "Your record type has more than one constructor, probably because you made it [<CLIMutable>]"
+        | Some ctor ->
         let parameters =
             ctor.GetParameters()
             |> Array.map (fun param ->

--- a/Fable.Remoting.DotnetClient/ClientRemoting.fs
+++ b/Fable.Remoting.DotnetClient/ClientRemoting.fs
@@ -89,7 +89,6 @@ module ClientRemoting =
         CustomHeaders: (string * string) list
     }
 
-    // Warning: if routeBuilder returns a path with a leading /, it will override any subpath inside baseUrl
     let createApi (baseUrl: string) =
         {
             RouteBuilder = None
@@ -149,7 +148,7 @@ module ClientRemoting =
                     )
                     |> Seq.toArray
 
-                let route = Uri(options.BaseUri, routeBuilder t.Name param.Name) |> string
+                let route = Uri(options.BaseUri, (routeBuilder t.Name param.Name).TrimStart('/')) |> string
                 if Array.length argTypes = 1 then
                     typedefof<ParameterlessServiceCall<_>>
                         .MakeGenericType(argTypes.[0])

--- a/Fable.Remoting.DotnetClient/ClientRemoting.fs
+++ b/Fable.Remoting.DotnetClient/ClientRemoting.fs
@@ -155,7 +155,7 @@ module ClientRemoting =
                     typedefof<ParameterlessServiceCall<_>>
                         .MakeGenericType(argTypes.[0])
                         .GetMethod("_Invoke", BindingFlags.NonPublic ||| BindingFlags.Static)
-                        .Invoke(null, [| route; client; options.AuthorizationToken; options.IsBinarySerialization |])
+                        .Invoke(null, [| route; client; options.IsBinarySerialization |])
                 else
                     let callerType =
                         match Array.length argTypes with
@@ -169,7 +169,7 @@ module ClientRemoting =
                         | 9 -> typedefof<ServiceCallerFunc9<_,_,_,_,_,_,_,_,_>>.MakeGenericType(argTypes)
                         | _ -> failwith "RPC methods with at most 8 curried arguments are supported"
 
-                    Activator.CreateInstance(callerType, route, client, options.AuthorizationToken, options.IsBinarySerialization)
+                    Activator.CreateInstance(callerType, route, client, options.IsBinarySerialization)
             )
 
         ctor.Invoke(parameters) :?> 't

--- a/Fable.Remoting.DotnetClient/ClientRemoting.fs
+++ b/Fable.Remoting.DotnetClient/ClientRemoting.fs
@@ -112,7 +112,7 @@ module ClientRemoting =
     let buildProxy<'t> (options: RemoteBuilderOptions) : 't =
         let isFSharpRecordType (t: Type) =
             match t.GetCustomAttributes<CompilationMappingAttribute>() |> Seq.toList with
-            | [ attr ] -> attr.SourceConstructFlags.HasFlag SourceConstructFlags.RecordType
+            | [ attr ] -> attr.SourceConstructFlags = SourceConstructFlags.RecordType
             | _ -> false
 
         let t = typeof<'t>

--- a/Fable.Remoting.DotnetClient/ClientRemoting.fs
+++ b/Fable.Remoting.DotnetClient/ClientRemoting.fs
@@ -1,0 +1,171 @@
+﻿namespace Fable.Remoting.DotnetClient
+
+open FSharp.Core.OptimizedClosures
+open System
+open System.Net.Http
+open System.Reflection
+
+module ClientRemoting =
+
+    type private ParameterlessServiceCall<'a>() =
+        static member _Invoke(route: string, client: HttpClient, isBinarySerialization) : Async<'a> =
+            Proxy.proxyPost<'a> [] route client isBinarySerialization
+
+    type private ServiceCallerFunc2<'a, 'b>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, Async<'b>>()
+
+        override _.Invoke(a) =
+            Proxy.proxyPost<'b> [ box a ] route client isBinarySerialization
+
+    type private ServiceCallerFunc3<'a, 'b, 'c>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, Async<'c>>()
+
+        override _.Invoke a =
+            fun b -> Proxy.proxyPost<'c> [ box a; box b ] route client isBinarySerialization
+
+        override _.Invoke(a, b) =
+            Proxy.proxyPost<'c> [ box a; box b ] route client isBinarySerialization
+
+    type private ServiceCallerFunc4<'a, 'b, 'c, 'd>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, Async<'d>>()
+
+        override _.Invoke a =
+            fun b c -> Proxy.proxyPost<'d> [ box a; box b; box c ] route client isBinarySerialization
+
+        override _.Invoke(a, b, c) =
+            Proxy.proxyPost<'d> [ box a; box b; box c ] route client isBinarySerialization
+
+    type private ServiceCallerFunc5<'a, 'b, 'c, 'd, 'e>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, 'd, Async<'e>>()
+
+        override _.Invoke a =
+            fun b c d -> Proxy.proxyPost<'e> [ box a; box b; box c; box d ] route client isBinarySerialization
+
+        override _.Invoke(a, b, c, d) =
+            Proxy.proxyPost<'e> [ box a; box b; box c; box d ] route client isBinarySerialization
+
+    type private ServiceCallerFunc6<'a, 'b, 'c, 'd, 'e, 'f>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, 'd, 'e, Async<'f>>()
+
+        override _.Invoke a =
+            fun b c d e -> Proxy.proxyPost<'f> [ box a; box b; box c; box d; box e ] route client isBinarySerialization
+
+        override _.Invoke(a, b, c, d, e) =
+            Proxy.proxyPost<'f> [ box a; box b; box c; box d; box e ] route client isBinarySerialization
+
+    type private ServiceCallerFunc7<'a, 'b, 'c, 'd, 'e, 'f, 'g>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, 'd, 'e, FSharpFunc<'f, Async<'g>>>()
+
+        override _.Invoke a =
+            fun b c d e f -> Proxy.proxyPost<'g> [ box a; box b; box c; box d; box e; box f ] route client isBinarySerialization
+
+        override _.Invoke(a, b, c, d, e) =
+            fun f -> Proxy.proxyPost<'g> [ box a; box b; box c; box d; box e; box f ] route client isBinarySerialization
+
+    type private ServiceCallerFunc8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, 'd, 'e, FSharpFunc<'f, FSharpFunc<'g, Async<'h>>>>() // the compiler will optimize `fun f g -> ...` to FSharpFunc<'f, 'g, 'h>
+
+        override _.Invoke a =
+            fun b c d e f g -> Proxy.proxyPost<'h> [ box a; box b; box c; box d; box e; box f; box g ] route client isBinarySerialization
+            
+        override _.Invoke(a, b, c, d, e) =
+            fun f g -> Proxy.proxyPost<'h> [ box a; box b; box c; box d; box e; box f; box g ] route client isBinarySerialization
+
+    type private ServiceCallerFunc9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i>(route: string, client: HttpClient, isBinarySerialization) =
+        inherit FSharpFunc<'a, 'b, 'c, 'd, 'e, FSharpFunc<'f, FSharpFunc<'g, FSharpFunc<'h, Async<'i>>>>>()
+
+        override _.Invoke a =
+            fun b c d e f g h -> Proxy.proxyPost<'i> [ box a; box b; box c; box d; box e; box f; box g; box h ] route client isBinarySerialization
+        
+        override _.Invoke(a, b, c, d, e) =
+            fun f g h -> Proxy.proxyPost<'i> [ box a; box b; box c; box d; box e; box f; box g; box h ] route client isBinarySerialization
+
+    type RemoteBuilderOptions = private {
+        routeBuilder: string -> string -> string
+        baseUri: Uri
+        client: HttpClient option
+        authToken: string option
+        isBinarySerialization: bool
+        customHeaders: (string * string) list
+    }
+
+    // Warning: if routeBuilder returns a path with a leading /, it will override any subpath inside baseUrl
+    let createApi (baseUrl: string) (routeBuilder: string -> string -> string) =
+        {
+            routeBuilder = routeBuilder
+            baseUri = Uri(baseUrl)
+            client = None
+            authToken = None
+            isBinarySerialization = false
+            customHeaders = []
+        }
+
+    let withAuthorizationHeader token options = { options with authToken = Some token }
+
+    let withBinarySerialization options = { options with isBinarySerialization = true }
+
+    let withHttpClient client options = { options with client = Some client }
+
+    let withCustomHeader (headers: (string * string) list) options = { options with customHeaders = headers @ options.customHeaders }
+
+    let buildProxy<'t> (options: RemoteBuilderOptions) : 't =
+        let isFSharpRecordType (t: Type) =
+            match t.GetCustomAttributes<CompilationMappingAttribute>() |> Seq.toList with
+            | [ attr ] -> attr.SourceConstructFlags.HasFlag SourceConstructFlags.RecordType
+            | _ -> false
+
+        let t = typeof<'t>
+        if not <| isFSharpRecordType t then failwithf "Type %s is not an F# record type" t.Name
+
+        let client = defaultArg options.client (new HttpClient())
+
+        options.customHeaders |> List.iter (fun (name, value) -> client.DefaultRequestHeaders.Add(name, value))
+
+        match options.authToken with
+        | Some token -> client.DefaultRequestHeaders.Add("Authorization", token)
+        | _ -> ()
+
+        let ctor = t.GetConstructors() |> Seq.exactlyOne
+        let parameters =
+            ctor.GetParameters()
+            |> Array.map (fun param ->
+                let funcType = param.ParameterType
+                let argTypes =
+                    Some funcType |> Seq.unfold (fun t ->
+                        match t with
+                        | Some t ->
+                            let generic = t.GetGenericTypeDefinition()
+                            if generic = typedefof<FSharpFunc<_,_>> then
+                                let args = t.GetGenericArguments()
+                                Some (args.[0], Some args.[1])
+                            elif generic = typedefof<Async<_>> then
+                                Some (t.GetGenericArguments().[0], None)
+                            else
+                                failwithf "Bad API record field %s, must be of type Async<'a> or a function returning Async<'a>" param.Name
+                        | None -> None
+                    )
+                    |> Seq.toArray
+
+                let route = Uri(options.baseUri, options.routeBuilder t.Name param.Name) |> string
+                if Array.length argTypes = 1 then
+                    typedefof<ParameterlessServiceCall<_>>
+                        .MakeGenericType(argTypes.[0])
+                        .GetMethod("_Invoke", BindingFlags.NonPublic ||| BindingFlags.Static)
+                        .Invoke(null, [| route; client; options.authToken; options.isBinarySerialization |])
+                else
+                    let callerType =
+                        match Array.length argTypes with
+                        | 2 -> typedefof<ServiceCallerFunc2<_,_>>.MakeGenericType(argTypes)
+                        | 3 -> typedefof<ServiceCallerFunc3<_,_,_>>.MakeGenericType(argTypes)
+                        | 4 -> typedefof<ServiceCallerFunc4<_,_,_,_>>.MakeGenericType(argTypes)
+                        | 5 -> typedefof<ServiceCallerFunc5<_,_,_,_,_>>.MakeGenericType(argTypes)
+                        | 6 -> typedefof<ServiceCallerFunc6<_,_,_,_,_,_>>.MakeGenericType(argTypes)
+                        | 7 -> typedefof<ServiceCallerFunc7<_,_,_,_,_,_,_>>.MakeGenericType(argTypes)
+                        | 8 -> typedefof<ServiceCallerFunc8<_,_,_,_,_,_,_,_>>.MakeGenericType(argTypes)
+                        | 9 -> typedefof<ServiceCallerFunc9<_,_,_,_,_,_,_,_,_>>.MakeGenericType(argTypes)
+                        | _ -> failwith "RPC methods with at most 8 curried arguments are supported"
+
+                    Activator.CreateInstance(callerType, route, client, options.authToken, options.isBinarySerialization)
+            )
+
+        ctor.Invoke(parameters) :?> 't

--- a/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
+++ b/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
@@ -15,6 +15,7 @@
         <Compile Include="Http.fs" />
         <Compile Include="Patterns.fs" />
         <Compile Include="Proxy.fs" />
+        <Compile Include="ClientRemoting.fs" />
     </ItemGroup>
 
     <!-- Need to conditionally bring in references for the .NET Framework 4.5 target -->

--- a/Fable.Remoting.DotnetClient/Http.fs
+++ b/Fable.Remoting.DotnetClient/Http.fs
@@ -6,23 +6,14 @@ open System.Text
 [<RequireQualifiedAccess>]
 module Http = 
 
-    type Authorisation = 
-        | Token of string
-        | NoToken 
-
     type ProxyRequestException(response: HttpResponseMessage, errorMsg, reponseText: string) = 
         inherit System.Exception(errorMsg)
         member __.Response = response 
         member __.StatusCode = response.StatusCode
         member __.ResponseText = reponseText 
 
-    let makePostRequest (client: HttpClient) (url : string) (requestBody : string) auth : Async<string> = 
+    let makePostRequest (client: HttpClient) (url : string) (requestBody : string) : Async<string> = 
         let contentType = "application/json"
-        match auth with 
-        | Token authToken -> 
-            // Add it to client
-            client.DefaultRequestHeaders.Add("Authorization", authToken)
-        | NoToken -> () 
 
         async {
             use postContent = new StringContent(requestBody, Encoding.UTF8, contentType)
@@ -39,13 +30,8 @@ module Http =
             else return raise ( ProxyRequestException(response, sprintf "Http error from server occured while making request to %s" url, responseText))
         }
 
-    let makePostRequestBinaryResponse (client: HttpClient) (url : string) (requestBody : string) auth : Async<byte[]> = 
+    let makePostRequestBinaryResponse (client: HttpClient) (url : string) (requestBody : string) : Async<byte[]> = 
         let contentType = "application/json"
-        match auth with 
-        | Token authToken -> 
-            // Add it to client
-            client.DefaultRequestHeaders.Add("Authorization", authToken)
-        | NoToken -> () 
 
         async {
             use postContent = new StringContent(requestBody, Encoding.UTF8, contentType)

--- a/Fable.Remoting.DotnetClient/Proxy.fs
+++ b/Fable.Remoting.DotnetClient/Proxy.fs
@@ -22,28 +22,28 @@ module Proxy =
         Fable.Remoting.MsgPack.Read.Reader(data).Read typeof<'t> :?> 't
 
     /// Sends a POST request to the specified url with the arguments of serialized to an input list
-    let proxyPost<'t> (functionArguments: obj list) url client auth isBinarySerialization =
+    let proxyPost<'t> (functionArguments: obj list) url client isBinarySerialization =
         let serializedInputArgs = JsonConvert.SerializeObject(functionArguments, converter)
         async {
             if isBinarySerialization then
-                let! data = Http.makePostRequestBinaryResponse client url serializedInputArgs auth
+                let! data = Http.makePostRequestBinaryResponse client url serializedInputArgs
                 return parseAsBinary<'t> data
             else
-                let! responseText = Http.makePostRequest client url serializedInputArgs auth
+                let! responseText = Http.makePostRequest client url serializedInputArgs
                 return parseAs<'t> responseText
         }
 
     /// Sends a POST request to the specified url safely with the arguments of serialized to an input list, if an exception is thrown, is it catched
-    let safeProxyPost<'t> (functionArguments: obj list) url client auth isBinarySerialization =
+    let safeProxyPost<'t> (functionArguments: obj list) url client isBinarySerialization =
         let serializedInputArgs = JsonConvert.SerializeObject(functionArguments, converter)
         async {
             if isBinarySerialization then
-                let! catchedResponse = Async.Catch (Http.makePostRequestBinaryResponse client url serializedInputArgs auth)
+                let! catchedResponse = Async.Catch (Http.makePostRequestBinaryResponse client url serializedInputArgs)
                 match catchedResponse with
                 | Choice1Of2 data -> return Ok (parseAsBinary<'t> data)
                 | Choice2Of2 thrownException -> return Error thrownException
             else
-                let! catchedResponse = Async.Catch (Http.makePostRequest client url serializedInputArgs auth)
+                let! catchedResponse = Async.Catch (Http.makePostRequest client url serializedInputArgs)
                 match catchedResponse with
                 | Choice1Of2 responseText -> return Ok (parseAs<'t> responseText)
                 | Choice2Of2 thrownException -> return Error thrownException
@@ -55,18 +55,18 @@ module Proxy =
             match typeof<'t>.GenericTypeArguments with
             | [|  |] -> name
             | manyArgs -> name.[0 .. name.Length - 3]
-        let mutable authHeader = Http.Authorisation.NoToken
         let client = defaultArg client (new HttpClient())
         /// Uses the specified string as the authorization header for the requests that the proxy makes to the server
         member __.authorisationHeader (header: string) =
-            authHeader <- Http.Authorisation.Token header
+            client.DefaultRequestHeaders.Remove("Authorization") |> ignore
+            client.DefaultRequestHeaders.Add("Authorization", header)
              
         member __.Call<'a> (expr: Expression<Func<'t, Async<'a>>>) : Task<'a> =
             let args = [  ]
             let memberExpr = unbox<MemberExpression> expr.Body  
             let functionName = memberExpr.Member.Name
             let route = builder typeName functionName
-            let asyncPost = proxyPost<'a> args route client authHeader isBinarySerialization
+            let asyncPost = proxyPost<'a> args route client isBinarySerialization
             Async.StartAsTask asyncPost 
 
         member __.Call<'a, 'b> (expr: Expression<Func<'t, FSharpFunc<'a, Async<'b>>>>, input: 'a) : Task<'b> =
@@ -74,7 +74,7 @@ module Proxy =
             let memberExpr = unbox<MemberExpression> expr.Body  
             let functionName = memberExpr.Member.Name
             let route = builder typeName functionName
-            let asyncPost = proxyPost<'b> args route client authHeader isBinarySerialization
+            let asyncPost = proxyPost<'b> args route client isBinarySerialization
             Async.StartAsTask asyncPost 
 
         member __.Call<'a, 'b, 'c> (expr: Expression<Func<'t, FSharpFunc<'a, FSharpFunc<'b, Async<'c>>>>>, arg1: 'a, arg2: 'b) : Task<'c> = 
@@ -82,7 +82,7 @@ module Proxy =
             let memberExpr = unbox<MemberExpression> expr.Body  
             let functionName = memberExpr.Member.Name
             let route = builder typeName functionName
-            let asyncPost = proxyPost<'c> args route client authHeader isBinarySerialization
+            let asyncPost = proxyPost<'c> args route client isBinarySerialization
             Async.StartAsTask asyncPost 
 
         member __.Call<'a, 'b, 'c, 'd> (expr: Expression<Func<'t, FSharpFunc<'a, FSharpFunc<'b, FSharpFunc<'c, Async<'d>>>>>>, arg1: 'a, arg2: 'b, arg3: 'c) : Task<'d> = 
@@ -90,7 +90,7 @@ module Proxy =
             let memberExpr = unbox<MemberExpression> expr.Body  
             let functionName = memberExpr.Member.Name
             let route = builder typeName functionName
-            let asyncPost = proxyPost<'d> args route client authHeader isBinarySerialization
+            let asyncPost = proxyPost<'d> args route client isBinarySerialization
             Async.StartAsTask asyncPost 
 
         /// Call the proxy function by wrapping it inside a quotation expr:
@@ -104,7 +104,7 @@ module Proxy =
             match expr with
             | ProxyLambda(methodName, args) ->
                 let route = builder typeName methodName
-                proxyPost<'u> args route client authHeader isBinarySerialization
+                proxyPost<'u> args route client isBinarySerialization
             | otherwise -> failwithf "Failed to process the following quotation expression\n%A\nThis could be due to the fact that you are providing complex function paramters to your called proxy function like nested records with generic paramters or lists, if that is the case, try binding the paramter to a value outside the qoutation expression and pass that value to the function instead" expr
 
         /// Call the proxy function safely by wrapping it inside a quotation expr and catching any thrown exception by the web request
@@ -121,7 +121,7 @@ module Proxy =
             match expr with
             | ProxyLambda(methodName, args) ->
                 let route = builder typeName methodName
-                safeProxyPost<'u> args route client authHeader isBinarySerialization
+                safeProxyPost<'u> args route client isBinarySerialization
             | otherwise -> failwithf "Failed to process quotation expression\n%A\nThis could be due to the fact that you are providing complex function paramters to your called proxy function like nested records with generic paramters or lists, if that is the case, try binding the paramter to a value outside the qoutation expression and pass that value to the function instead" expr
 
     /// Creates a proxy for a type with a route builder

--- a/README.md
+++ b/README.md
@@ -305,6 +305,38 @@ devServer: {
 ```
 That's it!
 
+## Dotnet Client
+You can also use client functionality in non-fable projects, such as a console application.
+
+Install `Fable.Remoting.DotnetClient` from nuget using Paket:
+```
+paket add Fable.Remoting.DotnetClient --project /path/to/Project.fsproj
+```
+Reference the shared types in your client project
+```
+<Compile Include="path/to/SharedTypes.fs" />
+```
+Start using the library:
+```fs
+open Fable.Remoting.DotnetClient
+open SharedTypes
+
+// studentApi : IStudentApi
+let studentApi =
+    ClientRemoting.createApi "http://localhost:8085/api/"
+    |> ClientRemoting.buildProxy<IStudentApi>
+
+async {
+  // students : Student[]
+  let! students = studentApi.allStudents()
+  for student in students do
+    // student : Student
+    printfn "Student %s is %d years old" student.Name student.Age
+}
+|> Async.StartImmediate
+```
+That's it!
+
 
 ## Adding a new route
  - Add another record field function to `IStudentApi`

--- a/documentation/src/dotnet-client.md
+++ b/documentation/src/dotnet-client.md
@@ -4,7 +4,7 @@ Although Fable.Remoting is initially implemented for communication between a .NE
 
 In fact, you can use the dotnet client with a dotnet server without a Fable project involved, think client-server interactions purely in F#. This has proven to make [integration testing](dotnet-integration-tests.md) extremely simple through this client.
 
-### Installation 
+## Installation 
 Install the library from [Nuget](https://www.nuget.org/packages/Fable.Remoting.DotnetClient/): 
 ```bash
 paket add Fable.Remoting.DotnetClient --project /path/to/App.fsproj
@@ -12,7 +12,34 @@ paket add Fable.Remoting.DotnetClient --project /path/to/App.fsproj
 dotnet add package Fable.Remoting.DotnetClient
 ```  
 
-### Using the library 
+## Using the library
+
+### The new way
+
+As you would expect, you need to reference the shared types and protocols to your client project: 
+```xml
+<Compile Include="..\Shared\SharedTypes.fs" />
+```
+With the new `ClientRemoting` API, the code is almost completely similar to the Fable client API, with only minor differences in proxy setup:
+```fs
+open Fable.Remoting.DotnetClient
+open SharedTypes
+
+let proxy =
+    // Note the builder is called ClientRemoting instead of just Remoting.
+    // This is to keep it unambiguous from the server-side Remoting API.
+    ClientRemoting.createApi "http://backend.api.io/v1" // Also note the base URI is no longer optional.
+    |> ClientRemoting.buildProxy<IServer>
+
+    async {
+        let! length = server.getLength "hello"
+        return length
+    }
+```
+
+To make the proxy generation logic work, your protocol record must be immutable, i.e. not marked as `[<CLIMutable>]`.
+
+### The old way
 
 As you would expect, you need to reference the shared types and protocols to your client project: 
 ```xml


### PR DESCRIPTION
This library comes up in first place in a google search for "F# RPC", and with good reason. However, the dotnet client feels like an after-thought and has always steered me away until now, so I decided to create a similar remote API builder to the one available in the JS client.

I tried to keep the public interface as similar to the JS client as possible, with the exception that a base path is mandatory for the dotnet client. I do believe the implementation is as performant as any normal F# function and should not have any extra overhead once the proxy is built.

I also noticed that setting the authorization header caused the code to choke on the second request onwards, so I fixed that as well.