### PR TITLE
Fix endpoint name discovery in the Giraffe adapter

### DIFF
--- a/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
+++ b/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
@@ -40,7 +40,7 @@ module GiraffeUtil =
         fun (next: HttpFunc) (ctx: HttpContext) -> task {
             let isProxyHeaderPresent = ctx.Request.Headers.ContainsKey "x-remoting-proxy"
             let impl = implBuilder ctx
-            let props = { Implementation = impl; EndpointName = ctx.Request.Path.Value; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
+            let props = { Implementation = impl; EndpointName = SubRouting.getNextPartOfPath ctx; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
                 HttpVerb = ctx.Request.Method.ToUpper (); IsContentBinaryEncoded = ctx.Request.ContentType = "application/octet-stream" }
 
             match! proxy props with


### PR DESCRIPTION
This change allows Giraffe subroutes (`subRoute "/api" >=> ...`) and, by extension, Saturn's `forward` (`router { forward "/api" ... }`) to be used with `Remoting.buildHttpHandler`.