### PR TITLE
Do not instantiate API record until it is necessary

### DIFF
--- a/Fable.Remoting.AspNetCore/Middleware.fs
+++ b/Fable.Remoting.AspNetCore/Middleware.fs
@@ -93,8 +93,7 @@ module internal Middleware =
         
         fun (next: HttpFunc) (ctx: HttpContext) -> task {
             let isProxyHeaderPresent = ctx.Request.Headers.ContainsKey "x-remoting-proxy"
-            let impl = implBuilder ctx
-            let props = { Implementation = impl; EndpointName = ctx.Request.Path.Value; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
+            let props = { ImplementationBuilder = (fun () -> implBuilder ctx); EndpointName = ctx.Request.Path.Value; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
                 HttpVerb = ctx.Request.Method.ToUpper (); IsContentBinaryEncoded = ctx.Request.ContentType = "application/octet-stream" }
 
             match! proxy props with

--- a/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
+++ b/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
@@ -39,8 +39,7 @@ module GiraffeUtil =
         
         fun (next: HttpFunc) (ctx: HttpContext) -> task {
             let isProxyHeaderPresent = ctx.Request.Headers.ContainsKey "x-remoting-proxy"
-            let impl = implBuilder ctx
-            let props = { Implementation = impl; EndpointName = SubRouting.getNextPartOfPath ctx; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
+            let props = { ImplementationBuilder = (fun () -> implBuilder ctx); EndpointName = SubRouting.getNextPartOfPath ctx; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
                 HttpVerb = ctx.Request.Method.ToUpper (); IsContentBinaryEncoded = ctx.Request.ContentType = "application/octet-stream" }
 
             match! proxy props with

--- a/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
+++ b/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
@@ -48,7 +48,7 @@ let invoke<'out, 'impl> (funcName: string) (record: 'impl) (input: Choice<obj[],
     inp.Write (inputBytes, 0, inputBytes.Length)
     inp.Position <- 0L
 
-    match proxy { Implementation = record; Input = inp; EndpointName = funcName; HttpVerb = "POST"; IsContentBinaryEncoded = false; IsProxyHeaderPresent = true } |> Async.RunSynchronously with
+    match proxy { ImplementationBuilder = (fun () -> record); Input = inp; EndpointName = funcName; HttpVerb = "POST"; IsContentBinaryEncoded = false; IsProxyHeaderPresent = true } |> Async.RunSynchronously with
     | Success (_, output) -> JsonConvert.DeserializeObject<'out>(System.Text.Encoding.UTF8.GetString (output.ToArray ()), converter)
     | InvocationResult.Exception (e, _) -> raise e
     | InvalidHttpVerb -> failwithf "Function %s does not expect POST" funcName

--- a/Fable.Remoting.Server/Proxy.fs
+++ b/Fable.Remoting.Server/Proxy.fs
@@ -124,7 +124,7 @@ let makeApiProxy<'impl, 'ctx> (options: RemotingOptions<'ctx, 'impl>): Invocatio
                             use ms = new MemoryStream ()
                             do! props.Input.CopyToAsync ms |> Async.AwaitTask
                             let props' = { Arguments = Choice1Of2 (ms.ToArray ()); ArgumentCount = 1; IsProxyHeaderPresent = props.IsProxyHeaderPresent }
-                            return! fieldProxy (shape.Get props.Implementation) props'
+                            return! fieldProxy (props.ImplementationBuilder () |> shape.Get) props'
                         else
                             use sr = new StreamReader (props.Input)
                             let! text = sr.ReadToEndAsync () |> Async.AwaitTask
@@ -140,7 +140,7 @@ let makeApiProxy<'impl, 'ctx> (options: RemotingOptions<'ctx, 'impl>): Invocatio
                                     token :?> JArray |> Seq.toList
 
                             let props' = { Arguments = Choice2Of2 args; ArgumentCount = args.Length; IsProxyHeaderPresent = props.IsProxyHeaderPresent }
-                            return! fieldProxy (shape.Get props.Implementation) props'
+                            return! fieldProxy (props.ImplementationBuilder () |> shape.Get) props'
                     with e ->
                         return InvocationResult.Exception (e, shape.MemberInfo.Name) }) }
 

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -61,7 +61,7 @@ type InvocationPropsInt = {
 
 type InvocationProps<'impl> = {
     Input: Stream
-    Implementation: 'impl
+    ImplementationBuilder: unit -> 'impl
     EndpointName: string
     HttpVerb: string
     IsContentBinaryEncoded: bool

--- a/Fable.Remoting.Suave/FableSuaveAdapter.fs
+++ b/Fable.Remoting.Suave/FableSuaveAdapter.fs
@@ -77,7 +77,6 @@ module SuaveUtil =
       fun (ctx: HttpContext) -> async {
           use inp = new MemoryStream (ctx.request.rawForm)
           let isRemotingProxy = ctx.request.headers |> List.exists (fun x -> fst x = "x-remoting-proxy")
-          let impl = implBuilder ctx
           let isContentBinaryEncoded = 
               ctx.request.headers
               |> List.tryFind (fun (key, _) -> key.ToLowerInvariant() = "content-type")
@@ -85,7 +84,7 @@ module SuaveUtil =
               |> function 
                 | Some "application/octet-stream" -> true 
                 | otherwise -> false
-          let props = { Implementation = impl; EndpointName = ctx.request.path; Input = inp; HttpVerb = ctx.request.rawMethod.ToUpper ();
+          let props = { ImplementationBuilder = (fun () -> implBuilder ctx); EndpointName = ctx.request.path; Input = inp; HttpVerb = ctx.request.rawMethod.ToUpper ();
               IsContentBinaryEncoded = isContentBinaryEncoded; IsProxyHeaderPresent = isRemotingProxy }
 
           match! proxy props with


### PR DESCRIPTION
Implements the second point in https://github.com/Zaid-Ajaj/Fable.Remoting/pull/177 all the way.

It's just a tiny optimization, so there's no need to release it on its own.