### PR TITLE
Added an option to set withCredentials

### DIFF
--- a/Fable.Remoting.ClientV2/Http.fs
+++ b/Fable.Remoting.ClientV2/Http.fs
@@ -10,6 +10,7 @@ module Http =
         HttpMethod = GET
         Url = "/"
         Headers = [ ]
+        WithCredentials = false
         RequestBody = Empty
     }
 
@@ -33,6 +34,10 @@ module Http =
 
     /// Appends a request with headers as key-value pairs
     let withHeaders headers (req: HttpRequest) = { req with Headers = headers  }
+    
+    /// Sets the withCredentials option on the XHR request, useful for CORS requests
+    let withCredentials withCredentials (req: HttpRequest) =
+        { req with WithCredentials = withCredentials }
 
     /// Appends a request with string body content
     let withBody body (req: HttpRequest) = { req with RequestBody = body }
@@ -49,6 +54,8 @@ module Http =
             // set the headers, must be after opening the request
             for (key, value) in req.Headers do
                 xhr.setRequestHeader(key, value)
+
+            xhr.withCredentials <- true
 
             xhr.onreadystatechange <- fun _ ->
                 match xhr.readyState with
@@ -74,6 +81,8 @@ module Http =
             // set the headers, must be after opening the request
             for (key, value) in req.Headers do
                 xhr.setRequestHeader(key, value)
+
+            xhr.withCredentials <- true
 
             xhr.onreadystatechange <- fun _ ->
                 match xhr.readyState with

--- a/Fable.Remoting.ClientV2/Http.fs
+++ b/Fable.Remoting.ClientV2/Http.fs
@@ -82,7 +82,7 @@ module Http =
             for (key, value) in req.Headers do
                 xhr.setRequestHeader(key, value)
 
-            xhr.withCredentials <- true
+            xhr.withCredentials <- req.WithCredentials
 
             xhr.onreadystatechange <- fun _ ->
                 match xhr.readyState with

--- a/Fable.Remoting.ClientV2/Remoting.fs
+++ b/Fable.Remoting.ClientV2/Remoting.fs
@@ -11,6 +11,7 @@ module Remoting =
         CustomHeaders = [ ]
         BaseUrl = None
         Authorization = None
+        WithCredentials = false
         RouteBuilder = sprintf ("/%s/%s")
         ResponseSerialization = Json
     }
@@ -30,6 +31,10 @@ module Remoting =
     /// Sets the authorization header of every request from the proxy
     let withAuthorizationHeader token (options: RemoteBuilderOptions) =
         { options with Authorization = Some token }
+
+    /// Sets the withCredentials option on the XHR request, which is useful for CORS scenarios
+    let withCredentials withCredentials (options: RemoteBuilderOptions) =
+        { options with WithCredentials = withCredentials }
 
     /// Specifies that the API uses binary serialization for responses
     let withBinarySerialization (options: RemoteBuilderOptions) =

--- a/Fable.Remoting.ClientV2/Types.fs
+++ b/Fable.Remoting.ClientV2/Types.fs
@@ -15,7 +15,8 @@ type HttpRequest = {
     HttpMethod: HttpMethod
     Url: string 
     Headers: (string * string) list  
-    RequestBody : RequestBody 
+    RequestBody : RequestBody
+    WithCredentials : bool
 }
  
 type HttpResponse = {
@@ -27,6 +28,7 @@ type RemoteBuilderOptions = {
     CustomHeaders : (string * string) list
     BaseUrl  : string option
     Authorization : string option
+    WithCredentials : bool
     RouteBuilder : (string -> string -> string)
     ResponseSerialization : SerializationType
 }


### PR DESCRIPTION
When using Fable.Remoting with CORS it was not possible to validate the logged user with their cookie because it was not sent in the request.