### PR TITLE
Update appveyor dotnet SDK version (7th attempt)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "5.257.0",
+      "version": "6.0.0-beta4",
       "commands": [
         "paket"
       ]

--- a/Fable.Remoting.IntegrationTests/DotnetClient/DotnetClient.fsproj
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/DotnetClient.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fable.Remoting.IntegrationTests/Server.Giraffe/Server.Giraffe.fsproj
+++ b/Fable.Remoting.IntegrationTests/Server.Giraffe/Server.Giraffe.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../Shared/SharedTypes.fs" />

--- a/Fable.Remoting.IntegrationTests/Server.Suave/Server.Suave.fsproj
+++ b/Fable.Remoting.IntegrationTests/Server.Suave/Server.Suave.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Fable.Remoting.Json.Tests/Fable.Remoting.Json.Tests.fsproj
+++ b/Fable.Remoting.Json.Tests/Fable.Remoting.Json.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fable.Remoting.Json\Fable.Remoting.Json.fsproj" />

--- a/Fable.Remoting.MsgPack.Tests/Fable.Remoting.MsgPack.Tests.fsproj
+++ b/Fable.Remoting.MsgPack.Tests/Fable.Remoting.MsgPack.Tests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fable.Remoting.MsgPack\Fable.Remoting.MsgPack.fsproj" />

--- a/Fable.Remoting.Server.Tests/Fable.Remoting.Server.Tests.fsproj
+++ b/Fable.Remoting.Server.Tests/Fable.Remoting.Server.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fable.Remoting.Suave.Tests/Fable.Remoting.Suave.Tests.fsproj
+++ b/Fable.Remoting.Suave.Tests/Fable.Remoting.Suave.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UITests/UITests.fsproj
+++ b/UITests/UITests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,10 @@ os: Visual Studio 2019 Preview
 
 # Install scripts. (runs after repo cloning)
 install:
-  # install latest dotnet core 3 preview
-  - cmd: choco install dotnetcore-sdk --pre
+  # install latest dotnet 5 sdk
+  - cmd: choco install dotnet-sdk --version 5.0.100
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
-  - ps: Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-  - ps: ./dotnet-install.ps1 --Version 5.0.101 -InstallDir 'C:\Program Files\dotnet'
 
   # # Update npm
   # # There seems to be issues with npm 5.4 in Windows

--- a/build.fsx
+++ b/build.fsx
@@ -30,7 +30,7 @@ let run workingDir fileName args =
 
 
 let proj file = (sprintf "Fable.Remoting.%s" file) </> (sprintf "Fable.Remoting.%s.fsproj" file)
-let testDll file = (sprintf "Fable.Remoting.%s.Tests" file) </> "bin" </> "Release" </> "netcoreapp3.0" </> (sprintf "Fable.Remoting.%s.Tests.dll" file)
+let testDll file = (sprintf "Fable.Remoting.%s.Tests" file) </> "bin" </> "Release" </> "netcoreapp3.1" </> (sprintf "Fable.Remoting.%s.Tests.dll" file)
 
 let JsonTestsDll = testDll "Json"
 let MsgPackTestsDll = testDll "MsgPack"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,4 @@
-version 5.257.0
+version 6.0.0
 source https://api.nuget.org/v3/index.json
 
 storage: none


### PR DESCRIPTION
Oof, that took some doing. I think the paket version warnings are caused by the fact that Fake is still using v5.