### PR TITLE
another try for support of DataTable and DataSet

### DIFF
--- a/Fable.Remoting.Giraffe.Tests/Types.fs
+++ b/Fable.Remoting.Giraffe.Tests/Types.fs
@@ -204,6 +204,9 @@ type IBinaryServer = {
     echoOptionalLong : Option<int64> -> Async<Option<int64>>
     echoSingleDULong : SingleLongCase -> Async<SingleLongCase>
     echoLongInGenericUnion : Maybe<int64> -> Async<Maybe<int64>>
+
+    echoDataTable : System.Data.DataTable -> Async<System.Data.DataTable>
+    echoDataSet : System.Data.DataSet -> Async<System.Data.DataSet>
 }
 
 module Async =
@@ -322,6 +325,8 @@ let binaryServer : IBinaryServer  = {
     echoOptionalLong =  Async.result
     echoSingleDULong = Async.result
     echoLongInGenericUnion = Async.result
+    echoDataTable = Async.result
+    echoDataSet = Async.result
 }
 
 type IReaderTest = { getPath: Async<string> }

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -182,4 +182,46 @@ let converterTest =
         test "Array of 3-tuples" {
             [| (1L, ":)", DateTime.Now); (4L, ":<", DateTime.Now) |] |> serializeDeserializeCompare
         }
+        #if !FABLE_COMPILER
+        test "datatable" {
+            let t = new System.Data.DataTable()
+            t.TableName <- "myname"
+            t.Columns.Add("a", typeof<int>) |> ignore
+            t.Columns.Add("b", typeof<string>) |> ignore
+            t.Rows.Add(1, "11111")  |> ignore
+            t.Rows.Add(2, "222222") |> ignore
+            use ms = new MemoryStream ()
+            MsgPack.Write.serializeObj t ms
+
+            let deserialized = MsgPack.Read.Reader(ms.ToArray ()).Read typeof<System.Data.DataTable> :?> System.Data.DataTable
+            Expect.equal deserialized.Columns.Count   t.Columns.Count  "column count"
+            Expect.equal deserialized.Rows.Count      t.Rows.Count     "row count"
+            Expect.equal deserialized.TableName       t.TableName      "table name"
+            Expect.equal deserialized.Rows.[0].["a"]  t.Rows.[0].["a"] "table.[0,'a']"
+            Expect.equal deserialized.Rows.[0].["b"]  t.Rows.[0].["b"] "table.[0,'b']"
+            Expect.equal deserialized.Rows.[1].["a"]  t.Rows.[1].["a"] "table.[1,'a']"
+            Expect.equal deserialized.Rows.[1].["b"]  t.Rows.[1].["b"] "table.[1,'b']"
+        }
+        test "dataset" {
+            let t = new System.Data.DataTable()
+            t.TableName <- "myname"
+            t.Columns.Add("a", typeof<int>) |> ignore
+            t.Columns.Add("b", typeof<string>) |> ignore
+            t.Rows.Add(1, "11111")  |> ignore
+            t.Rows.Add(2, "222222") |> ignore
+            let ds = new System.Data.DataSet()
+            ds.Tables.Add t
+            use ms = new MemoryStream ()
+            MsgPack.Write.serializeObj ds ms
+
+            let deserialized = MsgPack.Read.Reader(ms.ToArray ()).Read typeof<System.Data.DataSet> :?> System.Data.DataSet
+            Expect.equal deserialized.Tables.["myname"].Columns.Count   t.Columns.Count  "column count"
+            Expect.equal deserialized.Tables.["myname"].Rows.Count      t.Rows.Count     "row count"
+            Expect.equal deserialized.Tables.["myname"].TableName       t.TableName      "table name"
+            Expect.equal deserialized.Tables.["myname"].Rows.[0].["a"]  t.Rows.[0].["a"] "table.[0,'a']"
+            Expect.equal deserialized.Tables.["myname"].Rows.[0].["b"]  t.Rows.[0].["b"] "table.[0,'b']"
+            Expect.equal deserialized.Tables.["myname"].Rows.[1].["a"]  t.Rows.[1].["a"] "table.[1,'a']"
+            Expect.equal deserialized.Tables.["myname"].Rows.[1].["b"]  t.Rows.[1].["b"] "table.[1,'b']"
+        }
+        #endif
     ]

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -401,6 +401,8 @@ and private makeSerializerAux<'T> (ctx: TypeGenerationContext): Action<'T, Strea
         Action<_, _> (fun (tuple: 'T) out -> writeTuple tuple out elementSerializers) |> w
     | BclIsInstanceOfSystemDataSet _ ->
         Action<_, _> (fun (dataset: System.Data.DataSet) out -> writeDataSet dataset out) |> w
+    | BclIsInstanceOfSystemDataTable _ ->
+        Action<_, _> (fun (table: System.Data.DataTable) out -> writeDataTable table out) |> w
     | _ ->
         failwithf "Cannot serialize %s." typeof<'T>.Name
 


### PR DESCRIPTION
It works through WriteXmlSchema and WriteXml, it seems to roundtrip ok this time.

The issue was that newtonsoft.json had a very poor encoding of those objects and that I had no clue of necessary changes to FableConverter to override that.

I haven't looked from javascript client, but it should get two xml strings which can be used to assemble the same data.