### PR TITLE
Fix MsgPack decimal

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -1239,7 +1239,7 @@ let binaryServerTests =
                 let! output = binaryServer.echoInt64WithMeasure input
                 test.equal true (input = output)
 
-                let input = 333.35M<SomeUnit>
+                let input = 32313213121.1415926535m<SomeUnit>
                 let! output = binaryServer.echoDecimalWithMeasure input
                 test.equal true (input = output)
 
@@ -1481,7 +1481,7 @@ let msgPackTests =
             -5889845622625456789L |> serializeDeserializeCompare typeof<int64>
 
         testCase "Decimal" <| fun () ->
-            3.1415926535m |> serializeDeserializeCompare typeof<decimal>
+            32313213121.1415926535m |> serializeDeserializeCompare typeof<decimal>
 
         testCase "Map16 with map" <| fun () ->
             Map.ofArray [| for i in 1 .. 295 -> i, (i * i) |] |> serializeDeserializeCompare typeof<Map<int, int>>
@@ -1554,7 +1554,7 @@ let msgPackTests =
         testCase "Units of measure" <| fun () ->
             85<SomeUnit> |> serializeDeserializeCompare typeof<int<SomeUnit>>
             85L<SomeUnit> |> serializeDeserializeCompare typeof<int64<SomeUnit>>
-            85.44m<SomeUnit> |> serializeDeserializeCompare typeof<decimal<SomeUnit>>
+            32313213121.1415926535m<SomeUnit> |> serializeDeserializeCompare typeof<decimal<SomeUnit>>
             85.44f<SomeUnit> |> serializeDeserializeCompare typeof<float32<SomeUnit>>
             85.44<SomeUnit> |> serializeDeserializeCompare typeof<float<SomeUnit>>
         testCase "Value option" <| fun () ->

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -116,7 +116,7 @@ let converterTest =
             String.init 70_000 (fun _ -> "ΰ") |> serializeDeserializeCompare
         }
         test "Decimal" {
-            3.1415926535m |> serializeDeserializeCompare
+            32313213121.1415926535m |> serializeDeserializeCompare
         }
         test "Map16 with map" {
             Map.ofArray [| for i in 1 .. 295 -> i, (i * i) |] |> serializeDeserializeCompare

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -367,7 +367,11 @@ type Reader (data: byte[]) =
             | otherwise -> failwithf "Expecting %s at position %d, but the data contains an array." t.Name pos
 #endif
         elif t = typeof<decimal> || t.FullName = "Microsoft.FSharp.Core.decimal`1" then
-            x.ReadRawArray (4, typeof<int>) :?> int[] |> Decimal |> box
+#if !FABLE_COMPILER
+            arrayReaderCache.GetOrAdd (t, fun (_, (x: Reader)) -> x.ReadRawArray (4, typeof<int>) :?> int[] |> Decimal |> box) (len, x)
+#else
+            x.ReadRawArray (4, typeof<int>) |> box :?> int[] |> Decimal |> box
+#endif
         else
             failwithf "Expecting %s at position %d, but the data contains an array." t.Name pos
 

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -46,11 +46,9 @@ let inline interpretIntegerAs typ n =
 let inline interpretFloatAs typ n =
     if typ = typeof<float32> then float32 n |> box
     elif typ = typeof<float> then float n |> box
-    elif typ = typeof<decimal> then decimal n |> box
 #if FABLE_COMPILER
     elif typ.FullName = "Microsoft.FSharp.Core.float32`1" then float32 n |> box
     elif typ.FullName = "Microsoft.FSharp.Core.float`1" then float n |> box
-    elif typ.FullName = "Microsoft.FSharp.Core.decimal`1" then decimal n |> box
 #endif
     else failwithf "Cannot interpret float %A as %s." n typ.Name
 
@@ -368,7 +366,9 @@ type Reader (data: byte[]) =
                 box t
             | otherwise -> failwithf "Expecting %s at position %d, but the data contains an array." t.Name pos
 #endif
-         else
+        elif t = typeof<decimal> || t.FullName = "Microsoft.FSharp.Core.decimal`1" then
+            x.ReadRawArray (4, typeof<int>) :?> int[] |> Decimal |> box
+        else
             failwithf "Expecting %s at position %d, but the data contains an array." t.Name pos
 
     member x.ReadBin (len, t) =

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -589,6 +589,13 @@ module Fable =
             out.Add Format.Array32
             writeUnsigned32bitNumber (uint32 len) out false
 
+    let private writeDecimal (n: decimal) (out: ResizeArray<byte>) =
+        let bits = Decimal.GetBits n
+        
+        writeArrayHeader bits.Length out
+        for b in bits do
+            writeInt64 (int64 b) out
+
     let rec private writeArray (out: ResizeArray<byte>) t (arr: System.Collections.ICollection) =
         writeArrayHeader arr.Count out
 
@@ -690,7 +697,7 @@ module Fable =
             elif t.FullName = "Microsoft.FSharp.Core.int16`1" || t.FullName = "Microsoft.FSharp.Core.int32`1" || t.FullName = "Microsoft.FSharp.Core.int64`1" then
                 cacheGetOrAdd (t, fun x out -> writeInt64 (x :?> int64) out) x out
             elif t.FullName = "Microsoft.FSharp.Core.decimal`1" then
-                cacheGetOrAdd (t, fun x out -> writeDouble (x :?> decimal |> float) out) x out
+                cacheGetOrAdd (t, fun x out -> writeDecimal (x :?> decimal) out) x out
             elif t.FullName = "Microsoft.FSharp.Core.float`1" then
                 cacheGetOrAdd (t, fun x out -> writeDouble (x :?> float) out) x out
             elif t.FullName = "Microsoft.FSharp.Core.float32`1" then
@@ -720,7 +727,7 @@ module Fable =
     serializerCache.Add (typeof<UInt64>.FullName, fun x out -> writeUInt64 (x :?> UInt64) out)
     serializerCache.Add (typeof<float32>.FullName, fun x out -> writeSingle (x :?> float32) out)
     serializerCache.Add (typeof<float>.FullName, fun x out -> writeDouble (x :?> float) out)
-    serializerCache.Add (typeof<decimal>.FullName, fun x out -> writeDouble (x :?> decimal |> float) out)
+    serializerCache.Add (typeof<decimal>.FullName, fun x out -> writeDecimal (x :?> decimal) out)
     serializerCache.Add (typeof<byte[]>.FullName, fun x out -> writeBin (x :?> byte[]) out)
     serializerCache.Add (typeof<bigint>.FullName, fun x out -> writeBin ((x :?> bigint).ToByteArray ()) out)
     serializerCache.Add (typeof<Guid>.FullName, fun x out -> writeBin ((x :?> Guid).ToByteArray ()) out)


### PR DESCRIPTION
Decimals were be serialized as floats, which could result in losing precision (or rather the deserialized number would not match the original). Instead, we now use its binary representation using 4 integers.

Also fixes #235 with some better messages.