### PR TITLE
Add cancellation support

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -52,18 +52,13 @@ let serverTests =
                 | [ "http://api.example.com/IMusicStore/getLength" ] -> test.pass()
                 | otherwise -> test.fail()
 
-        testCaseAsync "Cancellation" <|
+        testCaseAsync "IServer.simulateLongComputation cancellation" <|
             async {
                 let tokenSource = new CancellationTokenSource(250)
                 let work = async {
-                    Fable.Core.JS.console.log("Working it")
-                    do! server.simulateLongComputation 5000
-//                    Fable.Core.JS.console.log("Computation finished %b", token.)   
-                    //printfn "IsCancleed: %b" token.IsCancellationRequested
-                    Fable.Core.JS.console.log("Computation finished")       
+                    do! server.simulateLongComputation 5000   
                 }
 
-                
                 let! result =
                     Async.StartAsPromise(work, tokenSource.Token)
                     |> Async.AwaitPromise
@@ -71,12 +66,11 @@ let serverTests =
                 
                 match result with
                 | Choice.Choice1Of2 _ ->
-                    printfn "Bad News" 
                     test.fail()
-                | Choice2Of2 ex ->
-                    printfn "Good News: %A" ex
+                | Choice2Of2 _ ->
                     test.pass()
             }
+           
         testCaseAsync "IServer.getLength" <|
             async {
                 let! result = server.getLength "hello"

--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -1,5 +1,6 @@
 ﻿module App
 
+open System.Threading
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Remoting.Client
@@ -51,6 +52,31 @@ let serverTests =
                 | [ "http://api.example.com/IMusicStore/getLength" ] -> test.pass()
                 | otherwise -> test.fail()
 
+        testCaseAsync "Cancellation" <|
+            async {
+                let tokenSource = new CancellationTokenSource(250)
+                let work = async {
+                    Fable.Core.JS.console.log("Working it")
+                    do! server.simulateLongComputation 5000
+//                    Fable.Core.JS.console.log("Computation finished %b", token.)   
+                    //printfn "IsCancleed: %b" token.IsCancellationRequested
+                    Fable.Core.JS.console.log("Computation finished")       
+                }
+
+                
+                let! result =
+                    Async.StartAsPromise(work, tokenSource.Token)
+                    |> Async.AwaitPromise
+                    |> Async.Catch
+                
+                match result with
+                | Choice.Choice1Of2 _ ->
+                    printfn "Bad News" 
+                    test.fail()
+                | Choice2Of2 ex ->
+                    printfn "Good News: %A" ex
+                    test.pass()
+            }
         testCaseAsync "IServer.getLength" <|
             async {
                 let! result = server.getLength "hello"

--- a/Fable.Remoting.ClientV2/Http.fs
+++ b/Fable.Remoting.ClientV2/Http.fs
@@ -55,9 +55,9 @@ module Http =
             | POST -> xhr.``open``("POST", req.Url)
 
             token.Register(fun _ ->
-                        xhr.abort()
-                        cancel(System.OperationCanceledException(token))
-                    ) |> ignore
+                xhr.abort()
+                cancel(System.OperationCanceledException(token))
+            ) |> ignore
             
             // set the headers, must be after opening the request
             for (key, value) in req.Headers do
@@ -97,13 +97,13 @@ module Http =
                 xhr.withCredentials <- req.WithCredentials
 
                 token.Register(fun _ ->
-                        xhr.abort()
-                        cancel(System.OperationCanceledException(token))
-                    ) |> ignore
+                    xhr.abort()
+                    cancel(System.OperationCanceledException(token))
+                ) |> ignore
                 
                 xhr.onreadystatechange <- fun _ ->
                     match xhr.readyState with
-                    | ReadyState.Done when xhr.status <> 0 && not token.IsCancellationRequested->
+                    | ReadyState.Done when xhr.status <> 0 && not token.IsCancellationRequested ->
                         let bytes = InternalUtilities.createUInt8Array xhr.response
                         resolve (bytes, xhr.status)
                     | _ ->

--- a/Fable.Remoting.ClientV2/Http.fs
+++ b/Fable.Remoting.ClientV2/Http.fs
@@ -67,7 +67,8 @@ module Http =
 
             xhr.onreadystatechange <- fun _ ->
                 match xhr.readyState with
-                | ReadyState.Done -> resolve { StatusCode = unbox xhr.status; ResponseBody = xhr.responseText }
+                | ReadyState.Done when xhr.status <> 0 && not token.IsCancellationRequested ->
+                    resolve { StatusCode = unbox xhr.status; ResponseBody = xhr.responseText }
                 | _ -> ignore()
 
             match req.RequestBody with
@@ -102,7 +103,7 @@ module Http =
                 
                 xhr.onreadystatechange <- fun _ ->
                     match xhr.readyState with
-                    | ReadyState.Done ->
+                    | ReadyState.Done when xhr.status <> 0 && not token.IsCancellationRequested->
                         let bytes = InternalUtilities.createUInt8Array xhr.response
                         resolve (bytes, xhr.status)
                     | _ ->

--- a/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
@@ -213,4 +213,6 @@ let server : IServer  = {
     echoDecimalKeyMap = Async.result
     echoLongKeyMap = Async.result
     echoIntKeyMap = Async.result
+    
+    simulateLongComputation = fun delay -> Async.Sleep delay
 }

--- a/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
@@ -365,6 +365,7 @@ type IServer = {
     // misc
     command: CommandLabel * RequesterIdentifier * Requests.Command -> Async<OperationErrorMessage>
     echoPosition : Position -> Async<Position>
+    simulateLongComputation: int -> Async<unit>
 }
 
 let routeBuilder typeName methodName =


### PR DESCRIPTION
Hi,

I've created a basic implementation of cancellation support by leveraging the f# async implicit token passing. I think the unit test shows a simple application for this. 

I'm making this a draft since I'm not sure if the integration is missing some key points or violates some guidelines for this project. 

Hope this helps.