### PR TITLE
Expose the request body to the error handler

### DIFF
--- a/Fable.Remoting.AspNetCore/Middleware.fs
+++ b/Fable.Remoting.AspNetCore/Middleware.fs
@@ -76,14 +76,14 @@ module internal Middleware =
       fun (next : HttpFunc) (ctx : HttpContext) ->
         task { return None }
 
-    let fail (ex: exn) (routeInfo: RouteInfo<HttpContext>) (requestBodyText: string option) (options: RemotingOptions<HttpContext, 't>) : HttpHandler = 
+    let fail (ex: exn) (routeInfo: RouteInfo<HttpContext>) (options: RemotingOptions<HttpContext, 't>) : HttpHandler = 
       let logger = options.DiagnosticsLogger
       fun (next : HttpFunc) (ctx : HttpContext) -> 
         task {
             match options.ErrorHandler with 
             | None -> return! setBody (Errors.unhandled routeInfo.methodName) logger next ctx 
             | Some errorHandler -> 
-                match errorHandler ex routeInfo requestBodyText with 
+                match errorHandler ex routeInfo with 
                 | Ignore -> return! setBody (Errors.ignored routeInfo.methodName) logger next ctx  
                 | Propagate error -> return! setBody (Errors.propagated error) logger next ctx  
         }
@@ -112,8 +112,8 @@ module internal Middleware =
                 return! next ctx
             | Exception (e, functionName, requestBodyText) ->
                 ctx.Response.StatusCode <- 500
-                let routeInfo = { methodName = functionName; path = ctx.Request.Path.ToString(); httpContext = ctx }
-                return! fail e routeInfo requestBodyText options next ctx
+                let routeInfo = { methodName = functionName; path = ctx.Request.Path.ToString(); httpContext = ctx; requestBodyText = requestBodyText }
+                return! fail e routeInfo options next ctx
             | InvalidHttpVerb ->
                 return! halt next ctx
             | EndpointNotFound ->

--- a/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
+++ b/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
@@ -27,20 +27,20 @@ module ServerParts =
     let webApp =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
         |> Remoting.fromValue server
 
     let webAppBinary =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
         |> Remoting.withBinarySerialization
         |> Remoting.fromValue binaryServer
 
     let otherWebApp =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
         |> Remoting.fromContext (fun ctx -> implementation)
 
     let readerApp =

--- a/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
+++ b/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
@@ -27,20 +27,20 @@ module ServerParts =
     let webApp =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.fromValue server
 
     let webAppBinary =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.withBinarySerialization
         |> Remoting.fromValue binaryServer
 
     let otherWebApp =
         Remoting.createApi()
         |> Remoting.withRouteBuilder builder
-        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.fromContext (fun ctx -> implementation)
 
     let readerApp =

--- a/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
+++ b/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs
@@ -19,13 +19,13 @@ module GiraffeUtil =
             setBodyFromString responseBody next ctx
 
     /// Handles thrown exceptions
-    let fail (ex: exn) (routeInfo: RouteInfo<HttpContext>) (requestBodyText: string option) (options: RemotingOptions<HttpContext, 't>) : HttpHandler =
+    let fail (ex: exn) (routeInfo: RouteInfo<HttpContext>) (options: RemotingOptions<HttpContext, 't>) : HttpHandler =
         let logger = options.DiagnosticsLogger
         fun (next : HttpFunc) (ctx : HttpContext) ->
             match options.ErrorHandler with
             | None -> setJsonBody (Errors.unhandled routeInfo.methodName) logger next ctx
             | Some errorHandler ->
-                match errorHandler ex routeInfo requestBodyText with
+                match errorHandler ex routeInfo with
                 | Ignore -> setJsonBody (Errors.ignored routeInfo.methodName) logger next ctx
                 | Propagate error -> setJsonBody (Errors.propagated error) logger next ctx
 
@@ -56,8 +56,8 @@ module GiraffeUtil =
                 return! next ctx |> Async.AwaitTask
             | Exception (e, functionName, requestBodyText) ->
                 ctx.Response.StatusCode <- 500
-                let routeInfo = { methodName = functionName; path = ctx.Request.Path.ToString(); httpContext = ctx }
-                return! fail e routeInfo requestBodyText options next ctx |> Async.AwaitTask
+                let routeInfo = { methodName = functionName; path = ctx.Request.Path.ToString(); httpContext = ctx; requestBodyText = requestBodyText }
+                return! fail e routeInfo options next ctx |> Async.AwaitTask
             | InvalidHttpVerb ->
                 return halt
             | EndpointNotFound ->

--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -21,7 +21,7 @@ module ServerParts =
         Remoting.createApi()
         |> Remoting.fromValue server
         |> Remoting.withRouteBuilder routeBuilder
-        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.buildWebPart
 
     let webApp =

--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -21,7 +21,7 @@ module ServerParts =
         Remoting.createApi()
         |> Remoting.fromValue server
         |> Remoting.withRouteBuilder routeBuilder
-        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
         |> Remoting.buildWebPart
 
     let webApp =

--- a/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
+++ b/Fable.Remoting.Server.Tests/ServerDynamicInvokeTests.fs
@@ -52,7 +52,7 @@ let invoke<'out, 'impl> (funcName: string) (record: 'impl) (input: Choice<obj[],
 
     match proxy { ImplementationBuilder = (fun () -> record); Input = inp; EndpointName = funcName; HttpVerb = "POST"; IsContentBinaryEncoded = false; IsProxyHeaderPresent = true } |> Async.RunSynchronously with
     | Success (_, output) -> JsonConvert.DeserializeObject<'out>(System.Text.Encoding.UTF8.GetString (output.ToArray ()), converter)
-    | InvocationResult.Exception (e, _) -> raise e
+    | InvocationResult.Exception (e, _, _) -> raise e
     | InvalidHttpVerb -> failwithf "Function %s does not expect POST" funcName
     | EndpointNotFound -> failwithf "Function %s was not found" funcName
 

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -22,6 +22,7 @@ type RouteInfo<'ctx> = {
     path: string
     methodName: string
     httpContext: 'ctx
+    requestBodyText: string option
 }
 
 type CustomErrorResult<'a> =
@@ -34,7 +35,7 @@ type ErrorResult =
     | Ignore
     | Propagate of obj
 
-type ErrorHandler<'context> = System.Exception -> RouteInfo<'context> -> string option -> ErrorResult
+type ErrorHandler<'context> = System.Exception -> RouteInfo<'context> -> ErrorResult
 
 /// A protocol implementation can be a static value provided or it can be generated from the Http context on every request.
 type ProtocolImplementation<'context, 'serverImpl> = 

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -34,7 +34,7 @@ type ErrorResult =
     | Ignore
     | Propagate of obj
 
-type ErrorHandler<'context> = System.Exception -> RouteInfo<'context> -> ErrorResult
+type ErrorHandler<'context> = System.Exception -> RouteInfo<'context> -> string option -> ErrorResult
 
 /// A protocol implementation can be a static value provided or it can be generated from the Http context on every request.
 type ProtocolImplementation<'context, 'serverImpl> = 
@@ -79,7 +79,7 @@ type InvocationResult =
     | Success of isBinaryOutput: bool * output: MemoryStream
     | EndpointNotFound
     | InvalidHttpVerb
-    | Exception of exn * functionName: string
+    | Exception of exn * functionName: string * requestBodyText: string option
 
 // an example is a list of arguments and the description of the example
 type Example = obj list * string

--- a/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
+++ b/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
@@ -19,8 +19,8 @@ let equal x y = Expect.equal true (x = y) (sprintf "%A = %A" x y)
 let pass () = Expect.equal true true ""   
 let fail () = Expect.equal false true ""
 
-let errorHandler (ex: exn) (_: RouteInfo<_>) (requestBodyText: string option) = 
-    printfn "Propagating exception message back to client: %s. Request body was: %A" ex.Message requestBodyText
+let errorHandler (ex: exn) (info: RouteInfo<_>) = 
+    printfn "Propagating exception message back to client: %s. Request body was: %A" ex.Message info.requestBodyText
     Propagate (ex.Message)
 
 let app = 

--- a/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
+++ b/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
@@ -19,8 +19,8 @@ let equal x y = Expect.equal true (x = y) (sprintf "%A = %A" x y)
 let pass () = Expect.equal true true ""   
 let fail () = Expect.equal false true ""
 
-let errorHandler (ex: exn) (_: RouteInfo<_>) = 
-    printfn "Propagating exception message back to client: %s" ex.Message
+let errorHandler (ex: exn) (_: RouteInfo<_>) (requestBodyText: string option) = 
+    printfn "Propagating exception message back to client: %s. Request body was: %A" ex.Message requestBodyText
     Propagate (ex.Message)
 
 let app = 

--- a/UITests/Program.fs
+++ b/UITests/Program.fs
@@ -15,14 +15,14 @@ let fableWebPart =
     Remoting.createApi()
     |> Remoting.fromContext (fun ctx -> server)
     |> Remoting.withRouteBuilder routeBuilder
-    |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+    |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
     |> Remoting.buildWebPart
 
 let fableWebPartBinary = 
     Remoting.createApi()
     |> Remoting.fromContext (fun ctx -> serverBinary)
     |> Remoting.withRouteBuilder routeBuilder
-    |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+    |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
     |> Remoting.withBinarySerialization
     |> Remoting.buildWebPart
 
@@ -106,7 +106,7 @@ module CookieTest =
         Remoting.createApi()
         |> Remoting.fromContext cookieServer
         |> Remoting.withRouteBuilder routeBuilder
-        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.buildWebPart
         >=> setCookie
 

--- a/UITests/Program.fs
+++ b/UITests/Program.fs
@@ -15,14 +15,14 @@ let fableWebPart =
     Remoting.createApi()
     |> Remoting.fromContext (fun ctx -> server)
     |> Remoting.withRouteBuilder routeBuilder
-    |> Remoting.withErrorHandler (fun ex _ -> Propagate ex.Message)
+    |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
     |> Remoting.buildWebPart
 
 let fableWebPartBinary = 
     Remoting.createApi()
     |> Remoting.fromContext (fun ctx -> serverBinary)
     |> Remoting.withRouteBuilder routeBuilder
-    |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+    |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
     |> Remoting.withBinarySerialization
     |> Remoting.buildWebPart
 
@@ -106,7 +106,7 @@ module CookieTest =
         Remoting.createApi()
         |> Remoting.fromContext cookieServer
         |> Remoting.withRouteBuilder routeBuilder
-        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate ex.Message)
+        |> Remoting.withErrorHandler (fun ex routeInfo requestBodyText -> Propagate (sprintf "Message: %s, request body: %A" ex.Message requestBodyText))
         |> Remoting.buildWebPart
         >=> setCookie
 


### PR DESCRIPTION
While this is technically a breaking change, I reckon it's worth adding. It allows the user to log the entire request body (if it was JSON), which is not only helpful for diagnosing general application errors, but especially so in cases when the input is malformed and not deserializable internally by Fable.Remoting (for whatever reason).