### PR TITLE
Implement char serialization in MsgPack

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -747,13 +747,12 @@ let binaryServerTests =
                 test.areEqual input output
             }
 
-        // TODO: implement char conversion in MsgPack
-        // testCaseAsync "IBinaryServer.echoRecordWithChar" <|
-        //     async {
-        //         let input = { CharValue = '*' }
-        //         let! output = binaryServer.echoRecordWithChar input
-        //         test.equal input.CharValue output.CharValue
-        //     }
+        testCaseAsync "IBinaryServer.echoRecordWithChar" <|
+            async {
+                let input = { CharValue = 'ŕ' }
+                let! output = binaryServer.echoRecordWithChar input
+                test.equal input.CharValue output.CharValue
+            }
 
         testCaseAsync "IBinaryServer.echoIntKeyMap" <|
             async {
@@ -1679,6 +1678,11 @@ let msgPackTests =
             [ Just 4; Nothing ] |> serializeDeserializeCompare typeof<Maybe<int> list>
         testCase "Array of 3-tuples" <| fun () ->
             [| (1L, ":)", DateTime.Now); (4L, ":<", DateTime.Now) |] |> serializeDeserializeCompare typeof<(int64 * string * DateTime)[]>
+        testCase "Chars" <| fun () ->
+            'q' |> serializeDeserializeCompare typeof<char>
+            'ψ' |> serializeDeserializeCompare typeof<char>
+            '☃' |> serializeDeserializeCompare typeof<char>
+            "☠️".[0] |> serializeDeserializeCompare typeof<char>
     ]
 
 let alltests =

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -249,5 +249,11 @@ let converterTest =
             Expect.equal deserialized.Tables.["myname"].Rows.[1].["a"]  t.Rows.[1].["a"] "table.[1,'a']"
             Expect.equal deserialized.Tables.["myname"].Rows.[1].["b"]  t.Rows.[1].["b"] "table.[1,'b']"
         }
+        test "Chars" {
+            'q' |> serializeDeserializeCompare
+            'ψ' |> serializeDeserializeCompare
+            '☃' |> serializeDeserializeCompare
+            "☠️".[0] |> serializeDeserializeCompare
+        }
         #endif
     ]

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -8,12 +8,14 @@ open System.Collections.Generic
 open FSharp.Reflection
 open System.Reflection
 
-let interpretStringAs (typ: Type) str =
+let interpretStringAs (typ: Type) (str: string) =
 #if FABLE_COMPILER
     box str
 #else
     if typ = typeof<string> then
         box str
+    elif typ = typeof<char> then
+        box str.[0]
     else
         // todo cacheable
         // String enum

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -334,6 +334,7 @@ and private makeSerializerAux<'T> (ctx: TypeGenerationContext): Action<'T, Strea
     | Shape.Bool -> Action<_, _> writeBool |> w
     | Shape.Byte -> Action<_, _> writeByte |> w
     | Shape.SByte -> Action<_, _> writeSByte |> w
+    | Shape.Char -> Action<_, _> (fun (c: char) out -> writeString (c.ToString ()) out) |> w
     | Shape.String -> Action<_, _> writeString |> w
     | Shape.Int16 -> Action<_, _> (fun (i: int16) out -> writeInt64 (int64 i) out) |> w
     | Shape.Int32 -> Action<_, _> (fun (i: int32) out -> writeInt64 (int64 i) out) |> w
@@ -718,6 +719,7 @@ module Fable =
     serializerCache.Add (typeof<sbyte>.FullName, fun x out -> writeInt64 (x :?> sbyte |> int64) out)
     serializerCache.Add (typeof<unit>.FullName, fun _ out -> writeNil out)
     serializerCache.Add (typeof<bool>.FullName, fun x out -> writeBool (x :?> bool) out)
+    serializerCache.Add (typeof<char>.FullName, fun x out -> writeString (x :?> string) out) // There are only strings in JS
     serializerCache.Add (typeof<string>.FullName, fun x out -> writeString (x :?> string) out)
     serializerCache.Add (typeof<int>.FullName, fun x out -> writeInt64 (x :?> int |> int64) out)
     serializerCache.Add (typeof<int16>.FullName, fun x out -> writeInt64 (x :?> int16 |> int64) out)


### PR DESCRIPTION
Implements #244.

Characters are converted to a string first in order to get the byte representation. Not the most efficient thing in the world but easy and supposedly rarely used. If anyone complains that their mission-critical systems are failing because of this, I'll find a better solution :).