### PR TITLE
Implement reflection cache for unions, tuples, options and maps

### DIFF
--- a/Fable.Remoting.Json/FableConverter.fs
+++ b/Fable.Remoting.Json/FableConverter.fs
@@ -43,17 +43,6 @@ type Kind =
 
 module Utilities =
     let quoted (input: string) = input.StartsWith "\"" && input.EndsWith "\""
-    let isUnionCaseWihoutFields (inputType: Type) (caseName: string) =
-        if FSharpType.IsUnion inputType then
-            let cases = FSharpType.GetUnionCases(inputType)
-            let foundCase =
-                cases
-                |> Array.tryFind (fun case -> case.Name = caseName)
-            match foundCase with
-            | None -> false
-            | Some case -> Seq.isEmpty (case.GetFields())
-        else
-            false
 
     let isNonStringPrimitiveType (inputType: Type) =
         inputType = typeof<DateTimeOffset>
@@ -71,88 +60,193 @@ module Utilities =
         || inputType = typeof<float>
         || inputType = typeof<byte>
 
+type IMapSerializer =
+    abstract member Serialize: obj * JsonWriter * JsonSerializer -> unit
+    abstract member Deserialize: Type * JsonReader * JsonSerializer -> obj
+
+module private Cache =
+    type TupleInfo = {
+        ElementReader: obj -> obj[]
+        ElementTypes: Type[]
+        Constructor: obj[] -> obj }
+
+    type UnionCase = {
+        Uci: UnionCaseInfo    
+        FieldReader: ValueOption<obj -> obj[]>
+        FieldTypes: Type[]
+        Constructor: obj[] -> obj }
+
+    type UnionInfo = {
+        TagReader: obj -> int
+        Cases: UnionCase[]
+        CaseByName: IReadOnlyDictionary<string, UnionCase> }
+
+    let jsonConverterTypes = ConcurrentDictionary<Type,Kind>()
+    let mapSerializerCache = ConcurrentDictionary<Type,IMapSerializer>()
+    let tupleInfoCache = ConcurrentDictionary<Type,TupleInfo>()
+    let unionTypeCache = ConcurrentDictionary<Type,Type>()
+    let unionInfoCache = ConcurrentDictionary<Type,UnionInfo>()
+
+open Cache
+
+module private ReflectionHelpers =
+    let bindingFlags = BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance
+
+    let getTupleInfo (t:Type) =
+        tupleInfoCache.GetOrAdd(t, Func<_,_>(fun t ->
+            { ElementReader = FSharpValue.PreComputeTupleReader(t)
+              ElementTypes = FSharpType.GetTupleElements(t)
+              Constructor = FSharpValue.PreComputeTupleConstructor(t) }))
+
+    let getUnionType (t:Type) =
+        unionTypeCache.GetOrAdd(t, fun t -> FSharpType.GetUnionCases(t, bindingFlags).[0].DeclaringType)
+
+    let getUnionInfo (t:Type) =
+        unionInfoCache.GetOrAdd(getUnionType t, Func<_,_>(fun t ->
+            let cases =
+                FSharpType.GetUnionCases(t, bindingFlags)
+                |> Array.map (fun uci ->
+                    let fields = uci.GetFields()
+                    let fieldReader =
+                        if fields.Length > 0 then
+                            FSharpValue.PreComputeUnionReader(uci, bindingFlags) |> ValueSome
+                        else
+                            ValueNone
+                    { Uci = uci
+                      FieldReader = fieldReader
+                      FieldTypes = fields |> Array.map (fun pi -> pi.PropertyType)
+                      Constructor = FSharpValue.PreComputeUnionConstructor(uci, bindingFlags) })
+            { TagReader = FSharpValue.PreComputeUnionTagReader(t, bindingFlags)
+              Cases = cases
+              CaseByName = cases.ToDictionary((fun case -> case.Uci.Name), id) }))
+
+    let getUnionCase value (union: UnionInfo) =
+        union.Cases.[union.TagReader value]
+
+    let getUnionCaseByName name (union: UnionInfo) =
+        union.CaseByName.[name]
+
+    let getUnionCaseInfo value (union: UnionInfo) =
+        (getUnionCase value union).Uci
+
+    let getUnionCaseInfoAndFields value (union: UnionInfo) =
+        let unionCase = getUnionCase value union
+        match unionCase.FieldReader with
+        | ValueSome reader -> unionCase.Uci, reader value
+        | _ -> unionCase.Uci, [||]
+
+    let isUnionCaseWihoutFields (t: Type) name =
+        if FSharpType.IsUnion t then
+            let union = getUnionInfo t
+            match union.CaseByName.TryGetValue name with
+            | true, case -> case.FieldTypes.Length = 0
+            | _ -> false
+        else
+            false
+
+    let getUnionKind (t: Type) =
+        t.GetCustomAttributes(false)
+        |> Array.tryPick (fun o ->
+            match o.GetType().FullName with
+            | "Fable.Core.PojoAttribute" -> Some Kind.PojoDU
+            | "Fable.Core.StringEnumAttribute" -> Some Kind.StringEnum
+            | _ -> None)
+        |> defaultArg <| Kind.Union
+
+    let unionOfRecords (t: Type) =
+        let union = getUnionInfo t
+        union.Cases
+        |> Array.forall (fun case ->
+            case.FieldTypes.Length = 1 && FSharpType.IsRecord(case.FieldTypes.[0]))
+
+open ReflectionHelpers
+
 /// Helper for serializing map/dict with non-primitive, non-string keys such as unions and records.
 /// Performs additional serialization/deserialization of the key object and uses the resulting JSON
 /// representation of the key object as the string key in the serialized map/dict.
 type MapSerializer<'k,'v when 'k : comparison>() =
-    static member Deserialize(t:Type, reader:JsonReader, serializer:JsonSerializer) =
-        let jsonToken = JToken.ReadFrom(reader)
-        if jsonToken.Type = JTokenType.Object then
-            // use an intermediate dictionary to deserialize the values
-            // where the keys are strings.
-            // then deserialize the keys separately
-            let initialDictionary = serializer.Deserialize<Dictionary<string,'v>>(jsonToken.CreateReader())
-            let dictionary = Dictionary<'k,'v>()
-            for kvp in initialDictionary do
-                if typeof<'k> = typeof<Guid> then
-                    // remove quotes from the Guid
-                    let cleanedGuid = kvp.Key.Replace("\"", "")
-                    let parsedGuid = Guid.Parse(cleanedGuid)
-                    dictionary.Add(unbox<'k> parsedGuid, kvp.Value)
-                else
-                    let shouldQuoteKey =
-                        not (Utilities.quoted kvp.Key)
-                        && (Utilities.isUnionCaseWihoutFields typeof<'k> kvp.Key || Utilities.isNonStringPrimitiveType typeof<'k>)
-                    let quotedKey =
-                        if shouldQuoteKey
-                        then "\"" + kvp.Key + "\""
-                        else kvp.Key
-                    use tempReader = new System.IO.StringReader(quotedKey)
-                    let key = serializer.Deserialize(tempReader, typeof<'k>) :?> 'k
-                    dictionary.Add(key, kvp.Value)
+    interface IMapSerializer with
+        member _.Deserialize(t:Type, reader:JsonReader, serializer:JsonSerializer) =
+            let jsonToken = JToken.ReadFrom(reader)
+            if jsonToken.Type = JTokenType.Object then
+                // use an intermediate dictionary to deserialize the values
+                // where the keys are strings.
+                // then deserialize the keys separately
+                let initialDictionary = serializer.Deserialize<Dictionary<string,'v>>(jsonToken.CreateReader())
+                let dictionary = Dictionary<'k,'v>()
+                for kvp in initialDictionary do
+                    if typeof<'k> = typeof<Guid> then
+                        // remove quotes from the Guid
+                        let cleanedGuid = kvp.Key.Replace("\"", "")
+                        let parsedGuid = Guid.Parse(cleanedGuid)
+                        dictionary.Add(unbox<'k> parsedGuid, kvp.Value)
+                    else
+                        let shouldQuoteKey =
+                            not (Utilities.quoted kvp.Key)
+                            && (isUnionCaseWihoutFields typeof<'k> kvp.Key || Utilities.isNonStringPrimitiveType typeof<'k>)
+                        let quotedKey =
+                            if shouldQuoteKey
+                            then "\"" + kvp.Key + "\""
+                            else kvp.Key
+                        use tempReader = new System.IO.StringReader(quotedKey)
+                        let key = serializer.Deserialize(tempReader, typeof<'k>) :?> 'k
+                        dictionary.Add(key, kvp.Value)
 
+                if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Map<_,_>>
+                then dictionary |> Seq.map (|KeyValue|) |> Map.ofSeq :> obj
+                elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Dictionary<_,_>>
+                then dictionary :> obj
+                else failwith "MapSerializer input type wasn't a Map or a Dictionary"
+            elif jsonToken.Type = JTokenType.Array then
+                serializer.Deserialize<list<'k * 'v>>(jsonToken.CreateReader())
+                |> Map.ofList :> obj
+            else
+                failwith "MapSerializer input type wasn't a Map or a Dictionary"
+
+        member _.Serialize(value: obj, writer:JsonWriter, serializer:JsonSerializer) =
+            let kvpSeq =
+                match value with
+                | :? Map<'k,'v> as mapObj -> mapObj |> Map.toSeq
+                | :? Dictionary<'k,'v> as dictObj -> dictObj |> Seq.map (|KeyValue|)
+                | _ -> failwith "MapSerializer input value wasn't a Map or a Dictionary"
+            writer.WriteStartObject()
+            use tempWriter = new System.IO.StringWriter()
+            kvpSeq
+                |> Seq.iter (fun (k,v) ->
+                    let key =
+                        tempWriter.GetStringBuilder().Clear() |> ignore
+                        serializer.Serialize(tempWriter, k)
+                        tempWriter.ToString()
+                    writer.WritePropertyName(key)
+                    serializer.Serialize(writer, v) )
+            writer.WriteEndObject()
+
+type MapStringKeySerializer<'v>() =
+    interface IMapSerializer with
+        member _.Deserialize(t:Type, reader:JsonReader, serializer:JsonSerializer) =
+            let dictJson = JObject.ReadFrom(reader) :?> JObject
+            let dictionary = Dictionary<string,'v>()
+            for prop in dictJson.Properties() do
+                let deserializedValue = serializer.Deserialize<'v>(prop.Value.CreateReader())
+                dictionary.Add(prop.Name, deserializedValue)
             if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Map<_,_>>
             then dictionary |> Seq.map (|KeyValue|) |> Map.ofSeq :> obj
             elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Dictionary<_,_>>
             then dictionary :> obj
             else failwith "MapSerializer input type wasn't a Map or a Dictionary"
-        elif jsonToken.Type = JTokenType.Array then
-            serializer.Deserialize<list<'k * 'v>>(jsonToken.CreateReader())
-            |> Map.ofList :> obj
-        else
-            failwith "MapSerializer input type wasn't a Map or a Dictionary"
-    static member Serialize(value: obj, writer:JsonWriter, serializer:JsonSerializer) =
-        let kvpSeq =
-            match value with
-            | :? Map<'k,'v> as mapObj -> mapObj |> Map.toSeq
-            | :? Dictionary<'k,'v> as dictObj -> dictObj |> Seq.map (|KeyValue|)
-            | _ -> failwith "MapSerializer input value wasn't a Map or a Dictionary"
-        writer.WriteStartObject()
-        use tempWriter = new System.IO.StringWriter()
-        kvpSeq
-            |> Seq.iter (fun (k,v) ->
-                let key =
-                    tempWriter.GetStringBuilder().Clear() |> ignore
-                    serializer.Serialize(tempWriter, k)
-                    tempWriter.ToString()
-                writer.WritePropertyName(key)
-                serializer.Serialize(writer, v) )
-        writer.WriteEndObject()
 
-type MapStringKeySerializer<'v>() =
-    static member Deserialize(t:Type, reader:JsonReader, serializer:JsonSerializer) =
-        let dictJson = JObject.ReadFrom(reader) :?> JObject
-        let dictionary = Dictionary<string,'v>()
-        for prop in dictJson.Properties() do
-            let deserializedValue = serializer.Deserialize<'v>(prop.Value.CreateReader())
-            dictionary.Add(prop.Name, deserializedValue)
-        if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Map<_,_>>
-        then dictionary |> Seq.map (|KeyValue|) |> Map.ofSeq :> obj
-        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Dictionary<_,_>>
-        then dictionary :> obj
-        else failwith "MapSerializer input type wasn't a Map or a Dictionary"
-    static member Serialize(value: obj, writer:JsonWriter, serializer:JsonSerializer) =
-        let kvpSeq =
-            match value with
-            | :? Map<string,'v> as mapObj -> mapObj |> Map.toSeq
-            | :? Dictionary<string,'v> as dictObj -> dictObj |> Seq.map (|KeyValue|)
-            | _ -> failwith "MapSerializer input value wasn't a Map or a Dictionary"
-        writer.WriteStartObject()
-        kvpSeq
-        |> Seq.iter (fun (k,v) ->
-            writer.WritePropertyName(k)
-            serializer.Serialize(writer, v) )
-        writer.WriteEndObject()
+        member _.Serialize(value: obj, writer:JsonWriter, serializer:JsonSerializer) =
+            let kvpSeq =
+                match value with
+                | :? Map<string,'v> as mapObj -> mapObj |> Map.toSeq
+                | :? Dictionary<string,'v> as dictObj -> dictObj |> Seq.map (|KeyValue|)
+                | _ -> failwith "MapSerializer input value wasn't a Map or a Dictionary"
+            writer.WriteStartObject()
+            kvpSeq
+            |> Seq.iter (fun (k,v) ->
+                writer.WritePropertyName(k)
+                serializer.Serialize(writer, v) )
+            writer.WriteEndObject()
 
 type DataSetSerializer() =
     static member Deserialize(t:Type, reader:JsonReader, serializer:JsonSerializer) =
@@ -198,15 +292,26 @@ type DataSetSerializer() =
         writer.WritePropertyName("data")
         writer.WriteValue(data)
         writer.WriteEndObject()
-module private Cache =
-    let jsonConverterTypes = ConcurrentDictionary<Type,Kind>()
-    let serializationBinderTypes = ConcurrentDictionary<string,Type>()
-    let unionCaseInfoCache = ConcurrentDictionary<Type,string*PropertyInfo array>()
 
-open Cache
-open Newtonsoft.Json.Linq
+module private MapHelpers =
+    let getMapSerializer (t: Type) =
+        mapSerializerCache.GetOrAdd(t, fun _ ->
+            let type' =
+                let mapTypes = t.GetGenericArguments()
+                typedefof<MapSerializer<_,_>>.MakeGenericType mapTypes
+            Activator.CreateInstance(type') :?> IMapSerializer)
 
- type InternalLong = { high : int; low: int; unsigned: bool }
+    let getMapStringKeySerializer (t: Type) =
+        mapSerializerCache.GetOrAdd(t, fun _ ->
+            let type' =
+                let mapTypes = t.GetGenericArguments()
+                let valueT = mapTypes.[1]
+                typedefof<MapStringKeySerializer<_>>.MakeGenericType valueT        
+            Activator.CreateInstance(type') :?> IMapSerializer)
+
+open MapHelpers
+
+type InternalLong = { high : int; low: int; unsigned: bool }
 
 /// Converts F# options, tuples and unions to a format understandable
 /// by Fable. Code adapted from Lev Gorodinski's original.
@@ -214,7 +319,6 @@ open Newtonsoft.Json.Linq
 type FableJsonConverter() =
     inherit Newtonsoft.Json.JsonConverter()
 
-    let bindingFlags = BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance
     let [<Literal>] PojoDU_TAG = "type"
 
     let advance(reader: JsonReader) =
@@ -231,48 +335,6 @@ type FableJsonConverter() =
         advance reader
         read 0 List.empty
 
-    let getUnionKind (t: Type) =
-        t.GetCustomAttributes(false)
-        |> Seq.tryPick (fun o ->
-            match o.GetType().FullName with
-            | "Fable.Core.PojoAttribute" -> Some Kind.PojoDU
-            | "Fable.Core.StringEnumAttribute" -> Some Kind.StringEnum
-            | _ -> None)
-        |> defaultArg <| Kind.Union
-
-    let unionOfRecords (t: Type) =
-        FSharpType.GetUnionCases(t, bindingFlags)
-        |> Seq.forall (fun case ->
-            let fields = case.GetFields()
-            fields.Length = 1 && FSharpType.IsRecord(fields.[0].PropertyType))
-
-    let getUci t name =
-        FSharpType.GetUnionCases(t, true)
-        |> Array.find (fun uci -> uci.Name = name)
-
-
-    let getUnionCaseNameAndFields value (t:Type) =
-        // The type-based caching doesn't work for struct unions, because all cases share one type.
-        if t.IsValueType then
-            let uci, fields = FSharpValue.GetUnionFields(value, t, true)
-            let uciName = uci.Name
-            uciName, fields
-        else
-            match unionCaseInfoCache.TryGetValue t with
-            | true, (uciName,fieldPropInfos) ->
-                let fields = [|
-                    for p in fieldPropInfos -> p.GetValue(value)
-                |]
-                uciName, fields
-            | false, _ ->
-                let uci, fields = FSharpValue.GetUnionFields(value, t, true)
-                let uciName = uci.Name
-                // cases without fields don't have distinct types -> don't cache them.
-                if fields.Length > 0 then
-                    let fieldPropInfos = uci.GetFields()
-                    unionCaseInfoCache.[t] <- (uciName,fieldPropInfos)
-                uciName, fields
-
     override x.CanConvert(t) =
         let kind =
             jsonConverterTypes.GetOrAdd(t, fun t ->
@@ -288,7 +350,7 @@ type FableJsonConverter() =
                 then Kind.BigInt
                 elif FSharpType.IsTuple t
                 then Kind.Tuple
-                elif (FSharpType.IsUnion(t, BindingFlags.Instance ||| BindingFlags.NonPublic ||| BindingFlags.Public) && t.Name <> "FSharpList`1")
+                elif (FSharpType.IsUnion(t, bindingFlags) && t.Name <> "FSharpList`1")
                 then getUnionKind t
                 elif t.IsGenericType
                     && (t.GetGenericTypeDefinition() = typedefof<Map<_,_>> || t.GetGenericTypeDefinition() = typedefof<Dictionary<_,_>>)
@@ -330,13 +392,13 @@ type FableJsonConverter() =
                 let milliseconds = ts.TotalMilliseconds
                 serializer.Serialize(writer, milliseconds)
             | true, Kind.Option ->
-                let _,fields = FSharpValue.GetUnionFields(value, t, true)
+                let _, fields = getUnionInfo t |> getUnionCaseInfoAndFields value
                 serializer.Serialize(writer, fields.[0])
             | true, Kind.Tuple ->
-                let values = FSharpValue.GetTupleFields(value)
-                serializer.Serialize(writer, values)
+                let tupleInfo = getTupleInfo t
+                serializer.Serialize(writer, tupleInfo.ElementReader value)
             | true, Kind.PojoDU ->
-                let uci, fields = FSharpValue.GetUnionFields(value, t,true)
+                let uci, fields = getUnionInfo t |> getUnionCaseInfoAndFields value
                 writer.WriteStartObject()
                 writer.WritePropertyName(PojoDU_TAG)
                 writer.WriteValue(uci.Name)
@@ -346,34 +408,29 @@ type FableJsonConverter() =
                     serializer.Serialize(writer, v))
                 writer.WriteEndObject()
             | true, Kind.StringEnum ->
-                let uci, _ = FSharpValue.GetUnionFields(value, t, true)
+                let uci = getUnionInfo t |> getUnionCaseInfo value
                 // TODO: Should we cache the case-name pairs somewhere? (see also `ReadJson`)
                 match uci.GetCustomAttributes(typeof<CompiledNameAttribute>) with
                 | [|:? CompiledNameAttribute as att|] -> att.CompiledName
                 | _ -> uci.Name.Substring(0,1).ToLowerInvariant() + uci.Name.Substring(1)
                 |> writer.WriteValue
             | true, Kind.Union ->
-                let uciName, fields = getUnionCaseNameAndFields value t
+                let uci, fields = getUnionInfo t |> getUnionCaseInfoAndFields value
                 if fields.Length = 0
-                then serializer.Serialize(writer, uciName)
+                then serializer.Serialize(writer, uci.Name)
                 else
                     writer.WriteStartObject()
-                    writer.WritePropertyName(uciName)
+                    writer.WritePropertyName(uci.Name)
                     if fields.Length = 1
                     then serializer.Serialize(writer, fields.[0])
                     else serializer.Serialize(writer, fields)
                     writer.WriteEndObject()
             | true, Kind.MapOrDictWithNonStringKey ->
-                let mapTypes = t.GetGenericArguments()
-                let mapSerializer = typedefof<MapSerializer<_,_>>.MakeGenericType mapTypes
-                let mapSerializeMethod = mapSerializer.GetMethod("Serialize")
-                mapSerializeMethod.Invoke(null, [| value; writer; serializer |]) |> ignore
+                let instance = getMapSerializer t
+                instance.Serialize(value, writer, serializer)
             | true, Kind.MapWithStringKey ->
-                let mapTypes = t.GetGenericArguments()
-                let valueT = mapTypes.[1]
-                let mapSerializer = typedefof<MapStringKeySerializer<_>>.MakeGenericType valueT
-                let mapSerializeMethod = mapSerializer.GetMethod("Serialize")
-                mapSerializeMethod.Invoke(null, [| value; writer; serializer |]) |> ignore
+                let instance = getMapStringKeySerializer t
+                instance.Serialize(value, writer, serializer)
             | true, Kind.DataTable
             | true, Kind.DataSet ->
                 DataSetSerializer.Serialize(value, writer, serializer)
@@ -429,11 +486,11 @@ type FableJsonConverter() =
                 let ts = TimeSpan.FromMilliseconds (float json)
                 upcast ts
         | true, Kind.Option ->
-            let cases = FSharpType.GetUnionCases(t, true)
+            let cases = (getUnionInfo t).Cases
             match reader.TokenType with
             | JsonToken.Null ->
                 serializer.Deserialize(reader, typeof<obj>) |> ignore
-                FSharpValue.MakeUnion(cases.[0], [||], bindingFlags)
+                cases.[0].Constructor [||]
             | _ ->
                 let innerType = t.GetGenericArguments().[0]
                 let innerType =
@@ -442,49 +499,51 @@ type FableJsonConverter() =
                     else innerType
                 let value = serializer.Deserialize(reader, innerType)
                 if isNull value
-                then FSharpValue.MakeUnion(cases.[0], [||], bindingFlags)
-                else FSharpValue.MakeUnion(cases.[1], [|value|], bindingFlags)
+                then cases.[0].Constructor [||]
+                else cases.[1].Constructor [|value|]
         | true, Kind.Tuple ->
             match reader.TokenType with
             | JsonToken.StartArray ->
-                let values = readElements(reader, FSharpType.GetTupleElements(t), serializer)
-                FSharpValue.MakeTuple(values |> List.toArray, t)
+                let tupleInfo = getTupleInfo t
+                let values = readElements(reader, tupleInfo.ElementTypes, serializer)
+                tupleInfo.Constructor (values |> List.toArray)
             | JsonToken.Null -> null // {"tuple": null}
             | _ -> failwith "invalid token"
         | true, Kind.PojoDU ->
             let dic = serializer.Deserialize(reader, typeof<Dictionary<string,obj>>) :?> Dictionary<string,obj>
             let uciName = dic.[PojoDU_TAG] :?> string
-            let uci = getUci t uciName
-            let fields = uci.GetFields() |> Array.map (fun fi -> Convert.ChangeType(dic.[fi.Name], fi.PropertyType))
-            FSharpValue.MakeUnion(uci, fields, bindingFlags)
+            let case = getUnionInfo t |> getUnionCaseByName uciName
+            let fields = case.Uci.GetFields() |> Array.map (fun fi -> Convert.ChangeType(dic.[fi.Name], fi.PropertyType))
+            case.Constructor fields
         | true, Kind.StringEnum ->
             let name = serializer.Deserialize(reader, typeof<string>) :?> string
-            FSharpType.GetUnionCases(t, true)
-            |> Array.tryFind (fun uci ->
+            (getUnionInfo t).Cases
+            |> Array.tryFind (fun case ->
                 // TODO: Should we cache the case-name pairs somewhere? (see also `WriteJson`)
+                let uci = case.Uci
                 match uci.GetCustomAttributes(typeof<CompiledNameAttribute>) with
                 | [|:? CompiledNameAttribute as att|] -> att.CompiledName = name
                 | _ ->
                     let name2 = uci.Name.Substring(0,1).ToLowerInvariant() + uci.Name.Substring(1)
                     name = name2)
             |> function
-                | Some uci -> FSharpValue.MakeUnion(uci, [||], bindingFlags )
+                | Some case -> case.Constructor [||]
                 | None -> failwithf "Cannot find case corresponding to '%s' for `StringEnum` type %s"
                                 name t.FullName
         | true, Kind.Union ->
             match reader.TokenType with
             | JsonToken.String ->
                 let name = serializer.Deserialize(reader, typeof<string>) :?> string
-                FSharpValue.MakeUnion(getUci t name, [||], bindingFlags)
+                let case = getUnionInfo t |> getUnionCaseByName name
+                case.Constructor [||]
             | JsonToken.StartObject ->
                 let content = serializer.Deserialize<JObject> reader
                 if content.Count = 1 && not (content.ContainsKey "__typename") then
                     let firstProperty = content.Properties().First()
                     let name = firstProperty.Name
-                    let uci = getUci t name
+                    let case = getUnionInfo t |> getUnionCaseByName name
 
-                    let itemTypes = uci.GetFields() |> Array.map (fun pi -> pi.PropertyType)
-                    if itemTypes.Length > 1 then
+                    if case.FieldTypes.Length > 1 then
                         // Then assume we have an array containing
                         // the elements of the union case
                         let items =
@@ -493,78 +552,65 @@ type FableJsonConverter() =
                             |> Seq.toArray
 
                         let values =
-                            itemTypes
+                            case.FieldTypes
                             |> Array.zip items
                             |> Array.map (fun (item, itemType) -> serializer.Deserialize(item.CreateReader(), itemType))
 
-                        FSharpValue.MakeUnion(uci, values, bindingFlags)
+                        case.Constructor values
                     else
-                        let value = serializer.Deserialize(firstProperty.Value.CreateReader(), itemTypes.[0])
-                        FSharpValue.MakeUnion(uci, [|value|], bindingFlags)
+                        let value = serializer.Deserialize(firstProperty.Value.CreateReader(), case.FieldTypes.[0])
+                        case.Constructor [|value|]
                 else if content.ContainsKey "__typename" && unionOfRecords t then
                     let property = content.Property("__typename")
                     let caseName = property.Value.ToObject<string>()
-                    let uci =
-                        FSharpType.GetUnionCases(t, true)
-                        |> Array.find (fun uci -> uci.Name.ToUpper() = caseName.ToUpper())
+                    let case =
+                        (getUnionInfo t).Cases
+                        |> Array.find (fun case -> case.Uci.Name.ToUpper() = caseName.ToUpper())
 
-                    let value = serializer.Deserialize(content.CreateReader(), uci.GetFields().[0].PropertyType)
-                    FSharpValue.MakeUnion(uci, [| value |], bindingFlags)
+                    let value = serializer.Deserialize(content.CreateReader(), case.FieldTypes.[0])
+                    case.Constructor [|value|]
                 else if content.Count = 3 && content.ContainsKey "tag" && content.ContainsKey "name" && content.ContainsKey "fields" then
                     let property = content.Property("name")
                     let caseName = property.Value.ToObject<string>()
-                    let uci = getUci t caseName
-                    let itemTypes = uci.GetFields() |> Array.map (fun pi -> pi.PropertyType)
-                    if itemTypes.Length > 1
+                    let case = getUnionInfo t |> getUnionCaseByName caseName
+                    if case.FieldTypes.Length > 1
                     then
-                        let values = readElements(content.["fields"].CreateReader(), itemTypes, serializer)
-                        FSharpValue.MakeUnion(uci, List.toArray values, bindingFlags)
+                        let values = readElements(content.["fields"].CreateReader(), case.FieldTypes, serializer)
+                        case.Constructor (List.toArray values)
                     else
-                        let value = serializer.Deserialize(content.["fields"].[0].CreateReader(), itemTypes.[0])
-                        FSharpValue.MakeUnion(uci, [|value|], bindingFlags)
+                        let value = serializer.Deserialize(content.["fields"].[0].CreateReader(), case.FieldTypes.[0])
+                        case.Constructor [|value|]
                 else
                     failwith "Unsupported"
             | JsonToken.Null -> null // for { "union": null }
             | JsonToken.StartArray ->
                 let unionArray = serializer.Deserialize<JToken>(reader) :?> JArray
                 let name = unionArray.[0].Value<string>()
-                let unionCaseInfo = getUci t name
-                let unionCaseTypes = unionCaseInfo.GetFields() |> Array.map (fun pi -> pi.PropertyType)
+                let case = getUnionInfo t |> getUnionCaseByName name
                 let values = Seq.skip 1 (unionArray.AsJEnumerable())
                 let parsedValue =
-                    [| 0 .. (unionCaseTypes.Length - 1) |]
+                    [| 0 .. (case.FieldTypes.Length - 1) |]
                     |> Array.map (fun index ->
                         let value = Seq.item index values
-                        value.ToObject(unionCaseTypes.[index], serializer))
-                    |> fun unionCaseValues -> FSharpValue.MakeUnion(unionCaseInfo, unionCaseValues, bindingFlags)
+                        value.ToObject(case.FieldTypes.[index], serializer))
+                    |> fun unionCaseValues -> case.Constructor unionCaseValues
                 parsedValue
             | _ -> failwithf "Invalid JSON token: %s" (reader.TokenType.ToString())
         | true, Kind.MapOrDictWithNonStringKey ->
-            let mapTypes = t.GetGenericArguments()
-            let mapSerializer = typedefof<MapSerializer<_,_>>.MakeGenericType mapTypes
-            let mapDeserializeMethod = mapSerializer.GetMethod("Deserialize")
-            mapDeserializeMethod.Invoke(null, [| t; reader; serializer |])
+            let instance = getMapSerializer t
+            instance.Deserialize(t, reader, serializer)
         | true, Kind.MapWithStringKey ->
-            if reader.TokenType = JsonToken.StartObject
-            then
-              // map is encoded as { key: value }
-              let mapTypes = t.GetGenericArguments()
-              let valueT = mapTypes.[1]
-              let mapSerializer = typedefof<MapStringKeySerializer<_>>.MakeGenericType valueT
-              let mapDeserializeMethod = mapSerializer.GetMethod("Deserialize")
-              mapDeserializeMethod.Invoke(null, [| t; reader; serializer |])
+            if reader.TokenType = JsonToken.StartObject then
+                let instance = getMapStringKeySerializer t
+                instance.Deserialize(t, reader, serializer)
             else
-              // map is encoded as [ [key, value] ] => rewrite as { key: value }
-              let tuplesArray = serializer.Deserialize<JToken>(reader) :?> JArray
-              let mapLiteral = JObject()
-              for tuple in tuplesArray do
-                let innerTuple = tuple :?> JArray
-                mapLiteral.Add(JProperty(tuple.[0].Value<string>(), tuple.[1]))
-              let mapTypes = t.GetGenericArguments()
-              let valueT = mapTypes.[1]
-              let mapSerializer = typedefof<MapStringKeySerializer<_>>.MakeGenericType valueT
-              let mapDeserializeMethod = mapSerializer.GetMethod("Deserialize")
-              mapDeserializeMethod.Invoke(null, [| t; mapLiteral.CreateReader(); serializer |])
+                // map is encoded as [ [key, value] ] => rewrite as { key: value }
+                let tuplesArray = serializer.Deserialize<JToken>(reader) :?> JArray
+                let mapLiteral = JObject()
+                for tuple in tuplesArray do
+                    mapLiteral.Add(JProperty(tuple.[0].Value<string>(), tuple.[1]))
+                let instance = getMapStringKeySerializer t
+                instance.Deserialize(t, mapLiteral.CreateReader(), serializer)
         | true, Kind.DataTable
         | true, Kind.DataSet ->
             DataSetSerializer.Deserialize(t, reader, serializer)


### PR DESCRIPTION
Hi Zaid! I recently identified a performance issue when serializing one of our F# domain models. The performance issue was caused by many repeated reflection calls at runtime in the FableConverter.

The "worst case" seems to be large DUs as keys in a Map, with many items in the Map. Our model looks something like this:

```
type MyUnion =
    | Case1
    | Case2
    ...
    | Case200

type MyRecord {
    Map1: Map<MyUnion, string>
    Map2: Map<MyUnion, string>
    ...
    Map20: Map<MyUnion, string> }
```

I've made some performance improvements which basically boil down to:
- Caching reflection calls for unions (including options) and tuples 
- Building lookup tables for union case names (mainly for deserialization)
- Pre-computing constructors for unions and tuples
- Caching map serialization instances to avoid runtime MethodInfo.Invoke calls

For our domain model (basically the code structure mentioned above) we saw serialization time decrease from `450ms` to `1.5ms`, which we're pretty happy with!
