### PR TITLE
fix int64 serialization

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -333,8 +333,10 @@ let serverTests =
             async {
                 let! fstResult = server.echoPrimitiveLong System.Int64.MaxValue
                 let! sndResult = server.echoPrimitiveLong System.Int64.MinValue
+                let! thirdResult = server.echoPrimitiveLong 637588453436987750L
                 do test.equal true (fstResult = System.Int64.MaxValue)
                 do test.equal true (sndResult = System.Int64.MinValue)
+                do test.equal true (thirdResult = 637588453436987750L)
             }
 
         testCaseAsync "IServer.echoComplexLong" <|
@@ -1550,6 +1552,8 @@ let msgPackTests =
 
         testCase "Long serialized as int16, 3 bytes" <| fun () ->
             60_000L |> serializeDeserializeCompareWithLength 3 typeof<int64>
+        testCase "uint64, 9 bytes" <| fun () ->
+            637588453436987750L |> serializeDeserializeCompareWithLength 9 typeof<int64>
 
         testCase "Array of 3 bools, 4 bytes" <| fun () ->
             [| false; true; true |] |> serializeDeserializeCompareWithLength 4 typeof<bool[]>

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -74,6 +74,9 @@ let converterTest =
         test "Long serialized as int16, 3 bytes" {
             60_000L |> serializeDeserializeCompareWithLength 3
         }
+        test "uint64, 9 bytes" {
+            637588453436987750L |> serializeDeserializeCompareWithLength 9
+        }
         test "Array of 3 bools, 4 bytes" {
             [| false; true; true |] |> serializeDeserializeCompareWithLength 4
         }

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -496,7 +496,10 @@ module Fable =
             out.Add b2
             out.Add b3
             out.Add b4
-            write32bitNumber b5 b6 b7 b8 out false
+            out.Add b5
+            out.Add b6
+            out.Add b7
+            out.Add b8
         else
             write32bitNumber b5 b6 b7 b8 out true
 

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -55,7 +55,10 @@ let inline write64bitNumberBytes b1 b2 b3 b4 b5 b6 b7 b8 (out: Stream) =
         out.WriteByte b2
         out.WriteByte b3
         out.WriteByte b4
-        write32bitNumberBytes b5 b6 b7 b8 out false
+        out.WriteByte b5
+        out.WriteByte b6
+        out.WriteByte b7
+        out.WriteByte b8
     else
         write32bitNumberBytes b5 b6 b7 b8 out true
 


### PR DESCRIPTION
Hi Zaid,

I noticed a bug on realy rare cases. On serializing int64 to MsgPack, while there are bytes with value 0 at position 5 or 6 in the byte representation, these positions will be removed. This leads to an invalid case. There is an int64 number with to less byte positions.

The byte representation of the number in the test case is: 8 217 43 82 0 0 153 102.
In the old implementation the 0 will be removed.