### PR TITLE
Make MsgPack treeshakable to reduce bundle size when MsgPack isn't used

### DIFF
--- a/Fable.Remoting.ClientV2/Proxy.fs
+++ b/Fable.Remoting.ClientV2/Proxy.fs
@@ -4,7 +4,6 @@ open System
 open Fable.Core
 open Fable.SimpleJson
 open Browser.Types
-open Fable.Remoting
 
 module internal Blob =
     /// Creates a Blob from the given input string
@@ -97,13 +96,13 @@ module Proxy =
             | None -> () ]
 
         let executeRequest =
-            if options.ResponseSerialization = MessagePack || isAsyncOfByteArray returnTypeAsync then
+            if options.CustomResponseSerialization.IsSome || isAsyncOfByteArray returnTypeAsync then
                 let onOk =
-                    match options.ResponseSerialization with
-                    | MessagePack ->
+                    match options.CustomResponseSerialization with
+                    | Some serializer ->
                         let returnType = getReturnType fieldType
-                        fun response -> MsgPack.Read.Reader(response).Read returnType
-                    | Json -> box
+                        fun response -> serializer response returnType
+                    | _ -> box
 
                 fun requestBody -> async {
                     // read as arraybuffer and deserialize

--- a/Fable.Remoting.ClientV2/Remoting.fs
+++ b/Fable.Remoting.ClientV2/Remoting.fs
@@ -4,6 +4,7 @@ open Fable.Core
 open Fable.SimpleJson
 open System
 open Microsoft.FSharp.Reflection
+open Fable.Remoting
 
 module Remoting =
     /// Starts with default configuration for building a proxy
@@ -13,7 +14,7 @@ module Remoting =
         Authorization = None
         WithCredentials = false
         RouteBuilder = sprintf ("/%s/%s")
-        ResponseSerialization = Json
+        CustomResponseSerialization = None
     }
 
     /// Defines how routes are built using the type name and method name. By default, the generated routes are of the form `/typeName/methodName`.
@@ -38,7 +39,8 @@ module Remoting =
 
     /// Specifies that the API uses binary serialization for responses
     let withBinarySerialization (options: RemoteBuilderOptions) =
-        { options with ResponseSerialization = MessagePack }
+        let serializer response returnType = MsgPack.Read.Reader(response).Read returnType
+        { options with CustomResponseSerialization = Some serializer }
 
 type Remoting() =
     static member buildProxy<'t>(options: RemoteBuilderOptions, [<Inject>] ?resolver: ITypeResolver<'t>) : 't =

--- a/Fable.Remoting.ClientV2/Types.fs
+++ b/Fable.Remoting.ClientV2/Types.fs
@@ -1,5 +1,7 @@
 namespace Fable.Remoting.Client 
 
+open System
+
 type HttpMethod = GET | POST 
 
 type RequestBody = 
@@ -7,9 +9,7 @@ type RequestBody =
     | Json of string 
     | Binary of byte[] 
 
-type SerializationType =
-    | Json
-    | MessagePack
+type CustomResponseSerializer = byte[] -> Type -> obj
 
 type HttpRequest = {
     HttpMethod: HttpMethod
@@ -30,7 +30,7 @@ type RemoteBuilderOptions = {
     Authorization : string option
     WithCredentials : bool
     RouteBuilder : (string -> string -> string)
-    ResponseSerialization : SerializationType
+    CustomResponseSerialization : CustomResponseSerializer option
 }
 
 type ProxyRequestException(response: HttpResponse, errorMsg, reponseText: string) = 


### PR DESCRIPTION
This small change moves the `MsgPack.Read` reference to `Remoting.withBinarySerialization`. As long as you don't call that function, bundlers are free to treeshake the MsgPack stuff out. Previously the hard reference to `MsgPack.Read` in `Proxy.executeRequest` prevented this.

I've tested it on an application using Fable 3.2.2 and Webpack 5.38.1. The production bundle size decreased with 15KB (post-minification, but before compression). Enough to make it worthwhile IMHO 😄.

This shouldn't be a breaking change either, unless someone uses the RemoteBuilderOptions record directly...