### PR TITLE
Make readInt() 3-4 times faster

### DIFF
--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -94,6 +94,7 @@ type SetDeserializer<'a when 'a : comparison> () =
 
 type Reader (data: byte[]) =
     let mutable pos = 0
+    let intBuf = Array.zeroCreate 8
 
 #if !FABLE_COMPILER
     static let arrayReaderCache = ConcurrentDictionary<Type, (int * Reader) -> obj> ()
@@ -112,13 +113,11 @@ type Reader (data: byte[]) =
         m (data, pos - len)
 #else
         if BitConverter.IsLittleEndian then
-            let arr = Array.zeroCreate len
-
             for i in 0 .. len - 1 do
-                arr.[i] <- data.[pos + len - 1 - i]
+                intBuf.[i] <- data.[pos + len - 1 - i]
 
             pos <- pos + len
-            m (arr, 0)
+            m (intBuf, 0)
         else
             pos <- pos + len
             m (data, pos - len)

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -105,13 +105,6 @@ type Reader (data: byte[]) =
 #endif
 
     let readInt len m =
-#if !FABLE_COMPILER
-        if BitConverter.IsLittleEndian then
-            Array.Reverse (data, pos, len)
-
-        pos <- pos + len
-        m (data, pos - len)
-#else
         if BitConverter.IsLittleEndian then
             for i in 0 .. len - 1 do
                 intBuf.[i] <- data.[pos + len - 1 - i]
@@ -121,7 +114,6 @@ type Reader (data: byte[]) =
         else
             pos <- pos + len
             m (data, pos - len)
-#endif
 
     member _.ReadByte () =
         pos <- pos + 1


### PR DESCRIPTION
`readint ()` uses a local temporary array for endian conversion. This array gets created and garbage collected for every value, putting a lot of strain on the garbage collector. By making the array a reusable class variable, we achieve 3-4 times faster execution. The class variable is only used by Fable, and since JavaScript is single-threaded there should not be any issues related to race conditions etc.