### PR TITLE
Speed up integer and float deserialization

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -1575,7 +1575,9 @@ let msgPackTests =
         testCase "Long serialized as int16, 3 bytes" <| fun () ->
             60_000L |> serializeDeserializeCompareWithLength 3 typeof<int64>
         testCase "uint64, 9 bytes" <| fun () ->
-            637588453436987750L |> serializeDeserializeCompareWithLength 9 typeof<int64>
+            637588453436987750UL |> serializeDeserializeCompareWithLength 9 typeof<uint64>
+        testCase "int64, 9 bytes" <| fun () ->
+            -137588453400987759L |> serializeDeserializeCompareWithLength 9 typeof<int64>
 
         testCase "Array of 3 bools, 4 bytes" <| fun () ->
             [| false; true; true |] |> serializeDeserializeCompareWithLength 4 typeof<bool[]>
@@ -1651,9 +1653,9 @@ let msgPackTests =
         testCase "Set32" <| fun () ->
             Set.ofArray [| for i in 1 .. 80_000 -> i |] |> serializeDeserializeCompare typeof<Set<int>>
 
-        testCase "Generic set" <| fun () ->
+        testCase "Recursive set" <| fun () ->
             Set.ofList [
-                { Name = "root"; Children = [ { Name = "Grandchild"; Children = [ ] } ] }
+                { Name = "root"; Children = [ { Name = "Grandchild"; Children = [ { Name = "root"; Children = [ { Name = "Grandchild2"; Children = [ ] } ] } ] } ] }
                 { Name = "root"; Children = [ { Name = "Grandchild2"; Children = [ ] } ] }
             ] |> serializeDeserializeCompare typeof<Set<RecursiveRecord>>
         testCase "Binary data bin8, 5 bytes" <| fun () ->
@@ -1665,7 +1667,15 @@ let msgPackTests =
         testCase "Array32 of long" <| fun () ->
             [| for _ in 1 .. 80_000 -> 5_000_000_000L |] |> serializeDeserializeCompare typeof<int64[]>
         testCase "Array32 of int32" <| fun () ->
-            [| 1 .. 100000 |] |> serializeDeserializeCompare typeof<int[]>
+            [| -100000 .. 100000 |] |> serializeDeserializeCompare typeof<int[]>
+        testCase "Array32 of uint32" <| fun () ->
+            [| 0u .. 200000u |] |> serializeDeserializeCompare typeof<uint32[]>
+        testCase "Array of single" <| fun () ->
+            [| Single.Epsilon; Single.MaxValue; Single.MinValue; Single.PositiveInfinity; Single.NegativeInfinity |] |> serializeDeserializeCompare typeof<float32[]>
+            [| -3f .. 0.5f .. 3f |] |> serializeDeserializeCompare typeof<float32[]>
+        testCase "Array of double" <| fun () ->
+            [| Double.Epsilon; Double.MaxValue; Double.MinValue; Double.PositiveInfinity; Double.NegativeInfinity |] |> serializeDeserializeCompare typeof<float[]>
+            [| -3_000. .. 0.1 .. 3_000. |] |> serializeDeserializeCompare typeof<float[]>
         testCase "Recursive record" <| fun () ->
             {
                 Name = "root"
@@ -1691,11 +1701,12 @@ let msgPackTests =
             Ok 15 |> serializeDeserializeCompare typeof<Result<int, string>>
             Error "yup" |> serializeDeserializeCompare typeof<Result<int, string>>
         testCase "Units of measure" <| fun () ->
-            85<SomeUnit> |> serializeDeserializeCompare typeof<int<SomeUnit>>
-            85L<SomeUnit> |> serializeDeserializeCompare typeof<int64<SomeUnit>>
-            32313213121.1415926535m<SomeUnit> |> serializeDeserializeCompare typeof<decimal<SomeUnit>>
-            85.44f<SomeUnit> |> serializeDeserializeCompare typeof<float32<SomeUnit>>
-            85.44<SomeUnit> |> serializeDeserializeCompare typeof<float<SomeUnit>>
+            85<SomeUnit> |> serializeDeserializeCompareWithLength 1 typeof<int<SomeUnit>>
+            85L<SomeUnit> |> serializeDeserializeCompareWithLength 1 typeof<int64<SomeUnit>>
+            -85L<SomeUnit> |> serializeDeserializeCompareWithLength 9 typeof<int64<SomeUnit>>
+            32313213121.1415926535m<SomeUnit> |> serializeDeserializeCompareWithLength 18 typeof<decimal<SomeUnit>>
+            80000005.44f<SomeUnit> |> serializeDeserializeCompareWithLength 5 typeof<float32<SomeUnit>>
+            80000000000005.445454<SomeUnit> |> serializeDeserializeCompareWithLength 9 typeof<float<SomeUnit>>
         testCase "Value option" <| fun () ->
             ValueSome "blah" |> serializeDeserializeCompare typeof<string voption>
             ValueNone |> serializeDeserializeCompare typeof<string voption>

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -30,20 +30,25 @@ let serializeDeserialize<'a> (value: 'a) =
 let serializeDeserializeCompareSequence (value: 'a) =
     use ms = new MemoryStream ()
     MsgPack.Write.serializeObj value ms
+    let data = ms.ToArray ()
+    let inputCopy = Array.copy data
 
-    let deserialized = MsgPack.Read.Reader(ms.ToArray ()).Read typeof<'a> :?> 'a
+    let deserialized = MsgPack.Read.Reader(data).Read typeof<'a> :?> 'a
 
     Expect.sequenceEqual value deserialized "Sequences must be equal."
+    Expect.sequenceEqual data inputCopy "The input data has been changed."
 
 let serializeDeserializeCompareWithLength<'a when 'a: equality> expectedLength (value: 'a) =
     use ms = new MemoryStream ()
     MsgPack.Write.serializeObj value ms
     let data = ms.ToArray ()
+    let inputCopy = Array.copy data
 
     let deserialized = MsgPack.Read.Reader(data).Read typeof<'a> :?> 'a
 
     equal value deserialized
-    Expect.equal data.Length expectedLength (sprintf "The expected and actual payload lengths must match.")
+    Expect.equal data.Length expectedLength "The expected and actual payload lengths must match."
+    Expect.sequenceEqual data inputCopy "The input data has been changed."
 
 let converterTest =
     testList "Converter Tests" [
@@ -75,7 +80,10 @@ let converterTest =
             60_000L |> serializeDeserializeCompareWithLength 3
         }
         test "uint64, 9 bytes" {
-            637588453436987750L |> serializeDeserializeCompareWithLength 9
+            637588453436987750UL |> serializeDeserializeCompareWithLength 9
+        }
+        test "int64, 9 bytes" {
+            -137588453400987759L |> serializeDeserializeCompareWithLength 9
         }
         test "Array of 3 bools, 4 bytes" {
             [| false; true; true |] |> serializeDeserializeCompareWithLength 4
@@ -141,7 +149,7 @@ let converterTest =
             Set.ofArray [| for i in 1 .. 80_000 -> i |] |> serializeDeserializeCompareSequence
         }
         test "Generic set" {
-            Set.ofList [ {| something = 5; somethnigElse = 10 |} ] |> serializeDeserializeCompare
+            Set.ofList [ {| something = 588854245464513.2465; somethnigElse = 58.24f |} ] |> serializeDeserializeCompare
             Set.ofList [ {| something = 5; somethnigElse = 10 |}; {| something = 5; somethnigElse = 11 |} ] |> serializeDeserializeCompare
             Set.ofList [ {| something = 6; somethnigElse = 10 |}; {| something = 5; somethnigElse = 10 |} ] |> serializeDeserializeCompare
         }
@@ -158,7 +166,18 @@ let converterTest =
             [| for i in 1L .. 80_000L -> 5_000_000_000L * (if i % 2L = 0L then -1L else 1L) |] |> serializeDeserializeCompare
         }
         test "Array32 of int32" {
-            [| 1 .. 100000 |] |> serializeDeserializeCompare
+            [| -100000 .. 100000 |] |> serializeDeserializeCompare
+        }
+        test "Array32 of uint32" {
+            [| 0u .. 200000u |] |> serializeDeserializeCompare
+        }
+        test "Array of single" {
+            [| Single.Epsilon; Single.MaxValue; Single.MinValue; Single.PositiveInfinity; Single.NegativeInfinity |] |> serializeDeserializeCompare
+            [| for i in -30_000 .. 30_000 -> float32 i * 10.356f |] |> serializeDeserializeCompare
+        }
+        test "Array of double" {
+            [| Double.Epsilon; Double.MaxValue; Double.MinValue; Double.PositiveInfinity; Double.NegativeInfinity |] |> serializeDeserializeCompare
+            [| for i in -30_000 .. 30_000 -> float i * 100.300056 |] |> serializeDeserializeCompare
         }
         test "Recursive record" {
             {
@@ -266,5 +285,13 @@ let converterTest =
             -5y |> serializeDeserializeCompare
             [| 0uy; 255uy; 100uy; 5uy |] |> serializeDeserializeCompare
             [| 0y; 100y; -100y; -5y |] |> serializeDeserializeCompare
+        }
+        test "Units of measure" {
+            85<SomeUnit> |> serializeDeserializeCompareWithLength 1
+            85L<SomeUnit> |> serializeDeserializeCompareWithLength 1
+            -85L<SomeUnit> |> serializeDeserializeCompareWithLength 9
+            32313213121.1415926535m<SomeUnit> |> serializeDeserializeCompareWithLength 18
+            80005.44f<SomeUnit> |> serializeDeserializeCompareWithLength 5
+            80000000000005.445454<SomeUnit> |> serializeDeserializeCompareWithLength 9
         }
     ]

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -139,7 +139,7 @@ type Reader (data: byte[]) =
 
     member _.ReadRawBin len =
         pos <- pos + len
-#if NETCOREAPP2_1_OR_GREATER
+#if NETCOREAPP2_1_OR_GREATER && !FABLE_COMPILER
         ReadOnlySpan (data, pos - len, len)
 #else
         data.[ pos - len .. pos - 1 ]
@@ -430,7 +430,7 @@ type Reader (data: byte[]) =
         if t = typeof<Guid> then
             Guid (x.ReadRawBin len) |> box
         elif t = typeof<byte[]> then
-#if NETCOREAPP2_1_OR_GREATER
+#if NETCOREAPP2_1_OR_GREATER && !FABLE_COMPILER
             (x.ReadRawBin len).ToArray () |> box
 #else
             box (x.ReadRawBin len)

--- a/Fable.Remoting.MsgPack/Read.fs
+++ b/Fable.Remoting.MsgPack/Read.fs
@@ -7,6 +7,10 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open FSharp.Reflection
 open System.Reflection
+open Microsoft.FSharp.NativeInterop
+
+#nowarn "9"
+#nowarn "51"
 
 let interpretStringAs (typ: Type) (str: string) =
 #if FABLE_COMPILER
@@ -23,7 +27,8 @@ let interpretStringAs (typ: Type) (str: string) =
         FSharpValue.MakeUnion (case, [||], true)
 #endif
 
-let inline interpretIntegerAs typ n =
+let inline interpretIntegerAs (typ: Type) n =
+#if !FABLE_COMPILER
     if typ = typeof<Int32> then int32 n |> box
     elif typ = typeof<Int64> then int64 n |> box
     elif typ = typeof<Int16> then int16 n |> box
@@ -31,28 +36,34 @@ let inline interpretIntegerAs typ n =
     elif typ = typeof<UInt64> then uint64 n |> box
     elif typ = typeof<UInt16> then uint16 n |> box
     elif typ = typeof<TimeSpan> then TimeSpan (int64 n) |> box
-#if FABLE_COMPILER
+    elif typ = typeof<byte> then byte n |> box
+    elif typ = typeof<sbyte> then sbyte n |> box
+    elif typ.IsEnum then Enum.ToObject (typ, int64 n)
+#else
+    if Object.ReferenceEquals (typ, typeof<Int32>) then int32 n |> box
+    elif typ.FullName = "System.Int64" then int64 n |> box
+    elif Object.ReferenceEquals (typ, typeof<Int16>) then int16 n |> box
+    elif Object.ReferenceEquals (typ, typeof<UInt32>) then uint32 n |> box
+    elif typ.FullName = "System.UInt64" then uint64 n |> box
+    elif Object.ReferenceEquals (typ, typeof<UInt16>) then uint16 n |> box
+    elif typ.FullName = "System.TimeSpan" then TimeSpan (int64 n) |> box
     elif typ.FullName = "Microsoft.FSharp.Core.int16`1" then int16 n |> box
     elif typ.FullName = "Microsoft.FSharp.Core.int32`1" then int32 n |> box
     elif typ.FullName = "Microsoft.FSharp.Core.int64`1" then int64 n |> box
-#endif
-    elif typ = typeof<byte> then byte n |> box
-    elif typ = typeof<sbyte> then sbyte n |> box
-#if !FABLE_COMPILER
-    elif typ.IsEnum then Enum.ToObject (typ, int64 n)
-#else
+    elif Object.ReferenceEquals (typ, typeof<byte>) then byte n |> box
+    elif Object.ReferenceEquals (typ, typeof<sbyte>) then sbyte n |> box
     elif typ.IsEnum then float n |> box
 #endif
     else failwithf "Cannot interpret integer %A as %s." n typ.Name
 
-let inline interpretFloatAs typ n =
+let inline interpretFloatAs (typ: Type) n =
+#if FABLE_COMPILER
+    box n
+#else
     if typ = typeof<float32> then float32 n |> box
     elif typ = typeof<float> then float n |> box
-#if FABLE_COMPILER
-    elif typ.FullName = "Microsoft.FSharp.Core.float32`1" then float32 n |> box
-    elif typ.FullName = "Microsoft.FSharp.Core.float`1" then float n |> box
-#endif
     else failwithf "Cannot interpret float %A as %s." n typ.Name
+#endif
 
 #if !FABLE_COMPILER
 type DictionaryDeserializer<'k,'v when 'k: equality and 'k: comparison> () =
@@ -94,7 +105,6 @@ type SetDeserializer<'a when 'a : comparison> () =
 
 type Reader (data: byte[]) =
     let mutable pos = 0
-    let intBuf = Array.zeroCreate 8
 
 #if !FABLE_COMPILER
     static let arrayReaderCache = ConcurrentDictionary<Type, (int * Reader) -> obj> ()
@@ -102,18 +112,20 @@ type Reader (data: byte[]) =
     static let setReaderCache = ConcurrentDictionary<Type, (int * Reader) -> obj> ()
     static let unionConstructorCache = ConcurrentDictionary<UnionCaseInfo, obj [] -> obj> ()
     static let unionCaseFieldCache = ConcurrentDictionary<Type * int, UnionCaseInfo * Type[]> ()
-#endif
-
-    let readInt len m =
+#else
+    let numberBuffer = Array.zeroCreate 8
+    
+    let readNumber len bytesInterpretation =
+        pos <- pos + len
+        
         if BitConverter.IsLittleEndian then
             for i in 0 .. len - 1 do
-                intBuf.[i] <- data.[pos + len - 1 - i]
+                numberBuffer.[i] <- data.[pos - 1 - i]
 
-            pos <- pos + len
-            m (intBuf, 0)
+            bytesInterpretation (numberBuffer, 0)
         else
-            pos <- pos + len
-            m (data, pos - len)
+            bytesInterpretation (data, pos - len)
+#endif
 
     member _.ReadByte () =
         pos <- pos + 1
@@ -133,29 +145,65 @@ type Reader (data: byte[]) =
     member x.ReadInt8 () =
         x.ReadByte () |> sbyte
 
-    member _.ReadUInt16 () =
-        readInt 2 BitConverter.ToUInt16
+    member x.ReadUInt16 () =
+        x.ReadInt16 () |> uint16
 
     member _.ReadInt16 () =
-        readInt 2 BitConverter.ToInt16
+        pos <- pos + 2
+        (int16 data.[pos - 2] <<< 8) ||| (int16 data.[pos - 1])
 
-    member _.ReadUInt32 () =
-        readInt 4 BitConverter.ToUInt32
+    member x.ReadUInt32 () =
+        x.ReadInt32 () |> uint32
 
     member _.ReadInt32 () =
-        readInt 4 BitConverter.ToInt32
+        pos <- pos + 4
+        (int data.[pos - 4] <<< 24) ||| (int data.[pos - 3] <<< 16) ||| (int data.[pos - 2] <<< 8) ||| (int data.[pos - 1])
 
-    member _.ReadUInt64 () =
-        readInt 8 BitConverter.ToUInt64
+    member x.ReadUInt64 () =
+        x.ReadInt64 () |> uint64
 
     member _.ReadInt64 () =
-        readInt 8 BitConverter.ToInt64
+#if !FABLE_COMPILER
+        pos <- pos + 8
+        (int64 data.[pos - 8] <<< 56) ||| (int64 data.[pos - 7] <<< 48) ||| (int64 data.[pos - 6] <<< 40) ||| (int64 data.[pos - 5] <<< 32) ||| 
+        (int64 data.[pos - 4] <<< 24) ||| (int64 data.[pos - 3] <<< 16) ||| (int64 data.[pos - 2] <<< 8) ||| (int64 data.[pos - 1])
+#else
+        readNumber 8 BitConverter.ToInt64
+#endif
 
-    member _.ReadFloat32 () =
-        readInt 4 BitConverter.ToSingle
+    member x.ReadFloat32 () =
+#if !FABLE_COMPILER
+        let mutable b = x.ReadInt32 ()
+        NativePtr.toNativeInt &&b |> NativePtr.ofNativeInt |> NativePtr.read<float32>
+#else
+        readNumber 4 BitConverter.ToSingle
 
-    member _.ReadFloat64 () =
-        readInt 8 BitConverter.ToDouble
+        // This is faster but does not yet work because of precision errors
+        //let sign = if (b >>> 31) = 0 then 1f else -1f
+        //let mutable e = (b >>> 23) &&& 0xff
+        //let m = b &&& 0x7fffff
+
+        //let m =
+        //    if e = 0 then
+        //        if m = 0 then
+        //            0f
+        //        else
+        //            e <- e - 126
+        //            1f / float32 0x7fffff
+        //    else
+        //        e <- e - 127
+        //        1f + float32 m / (float32 0x800000)
+
+        //sign * m * float32 (Math.Pow (2., float e))
+#endif
+
+    member x.ReadFloat64 () =
+#if !FABLE_COMPILER
+        let mutable b = x.ReadInt64 ()
+        NativePtr.toNativeInt &&b |> NativePtr.ofNativeInt |> NativePtr.read<float>
+#else
+        readNumber 8 BitConverter.ToDouble
+#endif
 
     member x.ReadMap (len: int, t: Type) =
 #if !FABLE_COMPILER
@@ -375,7 +423,6 @@ type Reader (data: byte[]) =
             x.ReadRawBin len |> box
         elif t = typeof<bigint> then
             x.ReadRawBin len |> bigint |> box
-
         else
             failwithf "Expecting %s at position %d, but the data contains bin." t.Name pos
 

--- a/Fable.Remoting.MsgPack/Write.fs
+++ b/Fable.Remoting.MsgPack/Write.fs
@@ -609,7 +609,7 @@ module Fable =
         
         writeArrayHeader bits.Length out
         for b in bits do
-            writeInt64 (int64 b) out
+            writeUnsigned32bitNumber (uint32 b) out true
 
     let rec private writeArray (out: ResizeArray<byte>) t (arr: System.Collections.ICollection) =
         writeArrayHeader arr.Count out


### PR DESCRIPTION
Deserializing an array of a million int32 is around 10x faster in JS (debug build, not optimized by terser), almost 20% on .NET. The same technique cannot be used for int64 (in JS) because the type is emulated and the operation would end up slower.

cc @juselius