### PR TITLE
Support tasks

### DIFF
--- a/ClientV2Tests/src/App.fs
+++ b/ClientV2Tests/src/App.fs
@@ -1488,6 +1488,21 @@ let binaryServerTests =
                 test.equal output input
             }
 #endif
+
+        testCaseAsync "IBinaryServer.pureTask" <|
+            async {
+                let! output = binaryServer.pureTask
+                test.equal 42 output
+            }
+
+        testCaseAsync "IBinaryServer.echoMapTask" <|
+            async {
+                let input = ["hello", 1] |> Map.ofList
+                let! output = binaryServer.echoMapTask input
+                match input = output with
+                | true -> test.pass()
+                | false -> test.fail()
+            }
     ]
 
 let cookieServer =

--- a/ClientV2Tests/src/ClientV2.fsproj
+++ b/ClientV2Tests/src/ClientV2.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+	<DefineConstants>TASK_AS_ASYNC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Fable.Remoting.IntegrationTests\Shared\SharedTypes.fs" />

--- a/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
@@ -2,6 +2,7 @@ module ServerImpl
 
 open SharedTypes
 open System
+open System.Threading.Tasks
 
 module Async =
     let result<'a> (x: 'a) : Async<'a> =
@@ -123,7 +124,9 @@ let serverBinary : IBinaryServer = {
     echoTimeOnlyMap = Async.result
     echoDateOnlyMap = Async.result
     echoRecordWithChar = Async.result
-}
+
+    pureTask = Task.FromResult 42
+    echoMapTask = fun map -> async { return map } |> Async.StartAsTask }
 
 // Async.result : 'a -> Async<'a>
 // a simple implementation, just return whatever value you get (echo the input)

--- a/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
@@ -285,7 +285,7 @@ type IBinaryServer = {
     echoNestedAnonRecord : Maybe<{| nested: {| name: string |} |}> -> Async<Maybe<{| nested: {| name: string |} |}>>
 
     // mixed Task on the server, Async in JS
-#if TASK_AS_ASYNC
+#if TASK_AS_ASYNC || FABLE_COMPILER
     pureTask : Async<int>
     echoMapTask : Map<string, int> -> Async<Map<string, int>>
 #else

--- a/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
@@ -1,6 +1,7 @@
 module SharedTypes
 
 open System
+open System.Threading.Tasks
 open Fable.Core
 
 type Record = {
@@ -282,6 +283,15 @@ type IBinaryServer = {
     echoLongInGenericUnion : Maybe<int64> -> Async<Maybe<int64>>
     echoAnonymousRecord : Maybe<{| name: string |}> -> Async<Maybe<{| name: string |}>>
     echoNestedAnonRecord : Maybe<{| nested: {| name: string |} |}> -> Async<Maybe<{| nested: {| name: string |} |}>>
+
+    // mixed Task on the server, Async in JS
+#if TASK_AS_ASYNC
+    pureTask : Async<int>
+    echoMapTask : Map<string, int> -> Async<Map<string, int>>
+#else
+    pureTask : Task<int>
+    echoMapTask : Map<string, int> -> Task<Map<string, int>>
+#endif
 }
 
 type IServer = {

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -47,11 +47,11 @@ type SerializationType =
     | Json
     | MessagePack
 
-type internal IShapeFSharpAsync =
+type internal IShapeFSharpAsyncOrTask =
     abstract Element: TypeShape
 
-type internal ShapeFSharpAsync<'T> () =
-    interface IShapeFSharpAsync with
+type internal ShapeFSharpAsyncOrTask<'T> () =
+    interface IShapeFSharpAsyncOrTask with
         member _.Element = shapeof<'T> :> _
 
 type InvocationPropsInt = {


### PR DESCRIPTION
Implements #134.

@isaacabraham, what's the goal here? Did you just want to avoid mucking around with Task <-> Async conversions in your code? This PR delivers on that front (though the directives I mentioned in https://github.com/Zaid-Ajaj/Fable.Remoting/issues/134#issuecomment-1037897673 are required now instead), but the conversions are still there, just pushed further down the stack, so no performance is gained. To eliminate them completely, we'd first have to reshuffle Paket groups and TFMs, because the relevant Remoting projects either don't target `net6.0` or are pinned to FSharp.Core 4.7.2 owing to the `lowest_matching` constraint.