### PR TITLE
Add support for optionally adding an error interceptor. Addresses #301

### DIFF
--- a/Fable.Remoting.ClientV2/Remoting.fs
+++ b/Fable.Remoting.ClientV2/Remoting.fs
@@ -15,6 +15,7 @@ module Remoting =
         WithCredentials = false
         RouteBuilder = sprintf ("/%s/%s")
         CustomResponseSerialization = None
+        WithErrorInterceptor = None
     }
 
     /// Defines how routes are built using the type name and method name. By default, the generated routes are of the form `/typeName/methodName`.
@@ -41,6 +42,10 @@ module Remoting =
     let withBinarySerialization (options: RemoteBuilderOptions) =
         let serializer response returnType = MsgPack.Read.Reader(response).Read returnType
         { options with CustomResponseSerialization = Some serializer }
+
+    /// Adds an error interceptor function to each request of the proxy. This allows you to have centralized logic that runs on specific error types (ie: 401 errors)
+    let withErrorInterceptor errorInterceptor (options: RemoteBuilderOptions) =
+        { options with WithErrorInterceptor = Some errorInterceptor }
 
 type Remoting() =
     static member buildProxy<'t>(options: RemoteBuilderOptions, [<Inject>] ?resolver: ITypeResolver<'t>) : 't =

--- a/Fable.Remoting.ClientV2/Types.fs
+++ b/Fable.Remoting.ClientV2/Types.fs
@@ -31,6 +31,7 @@ type RemoteBuilderOptions = {
     WithCredentials : bool
     RouteBuilder : (string -> string -> string)
     CustomResponseSerialization : CustomResponseSerializer option
+    WithErrorInterceptor : (int -> string -> unit) option
 }
 
 type ProxyRequestException(response: HttpResponse, errorMsg, reponseText: string) = 


### PR DESCRIPTION
This adds support  for optionally specifying an error interceptor for responses. The idea is that this interceptor would allow you to run centralized handlers for certain types of errors, without affecting the outcome of the response. For example, you could write an error interceptor to "handle" 401 responses by redirecting back to login, or a general 400-500 error interceptor that shows a toast notification. 

The signature of the interceptor is `statusCode: int -> responseBody: string -> unit`. You can set up the interceptor by calling `Remoting.withErrorInterceptor`: 

```
let errorInterceptor statusCode responseBody = 
    match statusCode with
    | 401 -> redirectToLogin()
    | 500 -> console.log "error"
    | _ -> () 

let musicStore = 
    Remoting.createApi()
    |> Remoting.withErrorInterceptor errorInterceptor  
    |> Remoting.buildproxy<IMusicStore>
```