### PR TITLE
Remove ITypeResolver to support Fable 4

### DIFF
--- a/Fable.Remoting.ClientV2/Remoting.fs
+++ b/Fable.Remoting.ClientV2/Remoting.fs
@@ -43,8 +43,8 @@ module Remoting =
         { options with CustomResponseSerialization = Some serializer }
 
 type Remoting() =
-    static member buildProxy<'t>(options: RemoteBuilderOptions, [<Inject>] ?resolver: ITypeResolver<'t>) : 't =
-        let resolvedType = resolver.Value.ResolveType()
+    /// For internal library use only.
+    static member buildProxy(options: RemoteBuilderOptions, resolvedType: Type) =
         let schemaType = createTypeInfo resolvedType
         match schemaType with
         | TypeInfo.Record getFields ->
@@ -98,3 +98,5 @@ type Remoting() =
         | _ ->
             failwithf "Cannot build proxy. Exepected type %s to be a valid protocol definition which is a record of functions" resolvedType.FullName
 
+    static member inline buildProxy<'t>(options: RemoteBuilderOptions) : 't =
+        Remoting.buildProxy(options, typeof<'t>)


### PR DESCRIPTION
Support for type injection is removed from Fable(.Core) 4, hence this workaround.

I've thought about dropping the Fable 2 tests and adding 4, but versions 3 and 4 of the compiler are distributed as dotnet tools and I don't think it's possible to have multiple versions side-by-side.