### PR TITLE
Make buildFromImplementation task statically compilable, add more tests

### DIFF
--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -535,6 +535,17 @@ let dotnetClientTests =
             let! output = server.echoTimeOnlyMap input
             Expect.equal output input "Output has gone through"
         }
+
+        testCaseAsync "IServer.pureTask" <| async {
+            let! output = server.pureTask |> Async.AwaitTask
+            Expect.equal output 42 "Pure task without parameters works"
+        }
+
+        testCaseAsync "IServer.echoMapTask" <| async {
+            let expected = Map.ofList [ "yup", 6 ]
+            let! output = server.echoMapTask expected |> Async.AwaitTask
+            Expect.equal output expected "Echoed map is correct"
+        }
     ]
 
 let testConfig =  { Expecto.Tests.defaultConfig with

--- a/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/ServerImpl.fs
@@ -227,4 +227,7 @@ let server : IServer  = {
     echoDateOnlyMap = Async.result
     simulateLongComputation = fun delay -> Async.Sleep delay
     echoRecordWithChar = Async.result
+
+    pureTask = Task.FromResult 42
+    echoMapTask = fun map -> Task.FromResult map
 }

--- a/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
+++ b/Fable.Remoting.IntegrationTests/Shared/SharedTypes.fs
@@ -397,6 +397,15 @@ type IServer = {
     command: CommandLabel * RequesterIdentifier * Requests.Command -> Async<OperationErrorMessage>
     echoPosition : Position -> Async<Position>
     simulateLongComputation: int -> Async<unit>
+
+    // mixed Task on the server, Async in JS
+#if TASK_AS_ASYNC || FABLE_COMPILER
+    pureTask : Async<int>
+    echoMapTask : Map<string, int> -> Async<Map<string, int>>
+#else
+    pureTask : Task<int>
+    echoMapTask : Map<string, int> -> Task<Map<string, int>>
+#endif
 }
 
 let routeBuilder typeName methodName =


### PR DESCRIPTION
Work around some mysterious Task compilation problems. https://github.com/Zaid-Ajaj/Fable.Remoting/pull/323 very likely introduced a performance regression because of this. Compiling Fable.Remoting.Giraffe in Release should now no longer give a warning.