### PR TITLE
Bump Microsoft.IO.RecyclableMemoryStream

### DIFF
--- a/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
+++ b/Fable.Remoting.Giraffe.Tests/MiddlewareTests.fs
@@ -11,6 +11,7 @@ open Microsoft.AspNetCore.Http
 open Expecto
 open Types
 open System.Net
+open Microsoft.IO
 
 let readerTest = reader {
     let! context = resolve<HttpContext>()
@@ -35,7 +36,7 @@ module ServerParts =
         |> Remoting.withRouteBuilder builder
         |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
         |> Remoting.withBinarySerialization
-        |> Remoting.withRecyclableMemoryStreamManager (Microsoft.IO.RecyclableMemoryStreamManager (ThrowExceptionOnToArray = true))
+        |> Remoting.withRecyclableMemoryStreamManager (RecyclableMemoryStreamManager (RecyclableMemoryStreamManager.Options (ThrowExceptionOnToArray = true)))
         |> Remoting.fromValue binaryServer
 
     let otherWebApp =

--- a/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
+++ b/Fable.Remoting.IntegrationTests/DotnetClient/Program.fs
@@ -11,6 +11,7 @@ open Suave.Operators
 open Suave.Filters
 open ServerImpl
 open System.Threading
+open Microsoft.IO
 
 module ServerParts =
 
@@ -22,7 +23,7 @@ module ServerParts =
         |> Remoting.fromValue server
         |> Remoting.withRouteBuilder routeBuilder
         |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
-        |> Remoting.withRecyclableMemoryStreamManager (Microsoft.IO.RecyclableMemoryStreamManager (ThrowExceptionOnToArray = true))
+        |> Remoting.withRecyclableMemoryStreamManager (RecyclableMemoryStreamManager (RecyclableMemoryStreamManager.Options (ThrowExceptionOnToArray = true)))
         |> Remoting.buildWebPart
 
     let webApp =

--- a/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
+++ b/Fable.Remoting.Suave.Tests/FableSuaveAdapterTests.fs
@@ -12,6 +12,7 @@ open Suave.Http
 open System
 open Expecto
 open Types
+open Microsoft.IO
 
 // Test helpers
 
@@ -28,7 +29,7 @@ let app =
   |> Remoting.fromValue implementation  
   |> Remoting.withDiagnosticsLogger (printfn "%s")
   |> Remoting.withErrorHandler errorHandler 
-  |> Remoting.withRecyclableMemoryStreamManager (Microsoft.IO.RecyclableMemoryStreamManager (ThrowExceptionOnToArray = true))
+  |> Remoting.withRecyclableMemoryStreamManager (RecyclableMemoryStreamManager (RecyclableMemoryStreamManager.Options (ThrowExceptionOnToArray = true)))
   |> Remoting.buildWebPart
 
 let postContent (input: string) =  new StringContent(sprintf "[%s]" input, System.Text.Encoding.UTF8)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ nuget Expecto 9.0.2
 nuget FSharp.Core >= 6.0.0
 nuget Microsoft.AspNetCore.Server.Kestrel ~> 2.2
 nuget Microsoft.AspNetCore.TestHost ~> 3.1
-nuget Microsoft.IO.RecyclableMemoryStream >= 2.2
+nuget Microsoft.IO.RecyclableMemoryStream ~> 3
 nuget Newtonsoft.Json >= 12.0
 nuget NUnit >= 3.12
 nuget PuppeteerSharp >= 7.1
@@ -34,7 +34,7 @@ group LatestNet5
     lowest_matching: true
     nuget Giraffe >= 5.0.0
     nuget FSharp.Core >= 6.0
-    nuget Microsoft.IO.RecyclableMemoryStream >= 2.2
+    nuget Microsoft.IO.RecyclableMemoryStream ~> 3
 
 group Client
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -264,7 +264,7 @@ NUGET
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Text.Encodings.Web (>= 6.0) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    Microsoft.IO.RecyclableMemoryStream (2.2)
+    Microsoft.IO.RecyclableMemoryStream (3.0)
       System.Memory (>= 4.5.4) - restriction: || (>= net462) (&& (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1))
     Microsoft.Net.Http.Headers (2.2.8) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
@@ -1169,7 +1169,7 @@ NUGET
       Utf8Json (>= 1.3.7)
     Giraffe.ViewEngine (1.4)
       FSharp.Core (>= 5.0)
-    Microsoft.IO.RecyclableMemoryStream (2.2)
+    Microsoft.IO.RecyclableMemoryStream (3.0)
     Newtonsoft.Json (13.0.1)
     Ply (0.3.1)
       FSharp.Core (>= 4.6.2)


### PR DESCRIPTION
Fixes #355.

Just need a recompile and new server packages.

Now that I think of it, Giraffe will also need updating.