### PR TITLE
Fix doc relative link

### DIFF
--- a/docs/client-setup/dotnet.md
+++ b/docs/client-setup/dotnet.md
@@ -2,7 +2,7 @@
 
 Although Fable.Remoting is initially implemented for communication between a .NET backend and a Fable frontend, the RPC story wouldn't be complete without a strongly typed dotnet client that can talk to the same backend using the protocol definition, that's why we have built one.
 
-In fact, you can use the dotnet client with a dotnet server without a Fable project involved, think client-server interactions purely in F#. This has proven to make [integration testing](dotnet-integration-tests.md) extremely simple through this client.
+In fact, you can use the dotnet client with a dotnet server without a Fable project involved, think client-server interactions purely in F#. This has proven to make [integration testing](/advanced/integration-tests-using-dotnet-client) extremely simple through this client.
 
 Install the library from [Nuget](https://www.nuget.org/packages/Fable.Remoting.DotnetClient/):
 ```bash

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -63,11 +63,11 @@ let musicStore : IMusicStore = {
 ```
 Now you are almost ready to expose the API to your client and have these functions being callable directly. Start by setting up the server with your web framework of choice: 
 
-- [Setup Giraffe](#/server-setup/giraffe)
-- [Setup Saturn](#/server-setup/saturn)
-- [Setup Asp.Net Core](#/server-setup/aspnet-core)
-- [Setup Suave](#/server-setup/suave)
+- [Setup Giraffe](/server-setup/giraffe)
+- [Setup Saturn](/server-setup/saturn)
+- [Setup Asp.Net Core](/server-setup/aspnet-core)
+- [Setup Suave](/server-setup/suave)
 
 Afterwards you can either:
-- [Setup Fable client](#/client-setup/fable)
-- [Setup dotnet client](#/client-setup/dotnet)
+- [Setup Fable client](/client-setup/fable)
+- [Setup dotnet client](/client-setup/dotnet)


### PR DESCRIPTION
Some relative links in docs doesn't redirect to intended page.