### PR TITLE
Resolve issue with Fable 4.13 and GET requests not firing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fable": {
-      "version": "4.9.0",
+      "version": "4.13.0",
       "commands": [
         "fable"
       ]

--- a/Fable.Remoting.Client/Proxy.fs
+++ b/Fable.Remoting.Client/Proxy.fs
@@ -178,7 +178,11 @@ module Proxy =
                     match inputArgumentTypes.Length with
                     | 1 when not (Convert.arrayLike inputArgumentTypes.[0]) ->
                         let typeInfo = TypeInfo.Tuple(fun _ -> inputArgumentTypes)
-                        let requestBodyJson = Convert.serialize inputArguments.[0] typeInfo
+                        let requestBodyJson =
+                            inputArguments
+                            |> Array.tryHead
+                            |> Option.map (fun arg -> Convert.serialize arg typeInfo)
+                            |> Option.defaultValue ""
                         RequestBody.Json requestBodyJson
                     | 1 ->
                         // for array-like types, use an explicit array surranding the input array argument


### PR DESCRIPTION
Fixes #361 

Updates to Fable 4.13

All `IntegrationTests` are passing