### PR TITLE
Adds XML docs to the `RouteInfo` type.

### DIFF
--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -19,9 +19,13 @@ type ParsingArgumentsError = { ParsingArgumentsError: string }
 
 /// Route information that is propagated to error handler when exceptions are thrown
 type RouteInfo<'ctx> = {
+    /// The full path of the request
     path: string
+    /// The last part of the path of the request
     methodName: string
+    /// The HttpContext of the request
     httpContext: 'ctx
+    /// The text content of the request, if any
     requestBodyText: string option
 }
 


### PR DESCRIPTION
I just happen to pass those by. When I was looking at that type I felt some (even if small) annotations missing, so I added them.