### PR TITLE
Minor code clean-up: Avoid dictionary double-lookups.

### DIFF
--- a/Fable.Remoting.Json/FableConverter.fs
+++ b/Fable.Remoting.Json/FableConverter.fs
@@ -568,9 +568,10 @@ type FableJsonConverter() =
         | true, Kind.MutableRecord -> 
             let content = serializer.Deserialize<JObject> reader
             let fields = t.GetProperties() |> Array.map (fun property -> 
-                if content.ContainsKey property.Name then 
-                    content[property.Name].ToObject(property.PropertyType, serializer)
-                else 
+                match content.TryGetValue property.Name with
+                | true, contentProp ->
+                    contentProp.ToObject(property.PropertyType, serializer)
+                | false, _ ->
                     null
             )
 

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -340,10 +340,11 @@ createTarget "IntegrationTestsLive" <| fun _ ->
     run clientUITests "dotnet" "run"
 
 let runTarget targetName =
-    if targets.ContainsKey targetName then
+    match targets.TryGetValue targetName with
+    | true, target ->
         let input = Unchecked.defaultof<TargetParameter>
-        targets[targetName] input
-    else
+        target input
+    | false, _ -> 
         printfn $"Could not find build target {targetName}"
 
 [<EntryPoint>]


### PR DESCRIPTION
Avoid dictionary double-lookups.