### PR TITLE
Fix Fable.Remoting.Client

### DIFF
--- a/Fable.Remoting.Client/Extensions.fs
+++ b/Fable.Remoting.Client/Extensions.fs
@@ -25,6 +25,8 @@ module InternalUtilities =
     /// Returns whether the input byte array is a typed array of type Uint8Array
     [<Emit "$0 instanceof Uint8Array">]
     let isUInt8Array (data: obj) : bool = jsNative
+    [<Emit "new FormData()">]
+    let createFormData (): obj = jsNative
 
     /// Creates a typed byte array of binary data if it is not already typed
     let toUInt8Array(data: byte[]) : byte[] =

--- a/Fable.Remoting.Client/Http.fs
+++ b/Fable.Remoting.Client/Http.fs
@@ -2,6 +2,7 @@ namespace Fable.Remoting.Client
 
 open Browser
 open Browser.Types
+open Fable.Core
 open Fable.Core.JsInterop
 
 module Http =

--- a/Fable.Remoting.Client/Http.fs
+++ b/Fable.Remoting.Client/Http.fs
@@ -2,6 +2,7 @@ namespace Fable.Remoting.Client
 
 open Browser
 open Browser.Types
+open Fable.Core.JsInterop
 
 module Http =
 
@@ -78,10 +79,10 @@ module Http =
             | Empty -> xhr.send()
             | RequestBody.Json content -> xhr.send(content)
             | Multipart blobs ->
-                let form = Browser.XMLHttpRequest.FormData.Create ()
+                let form = emitJsExpr () "new FormData()"
 
                 for i in 0 .. blobs.Length - 1 do
-                    form.append (i.ToString (), blobs.[i])
+                    form?append (i.ToString (), blobs.[i])
 
                 xhr.send form
 

--- a/Fable.Remoting.Client/Http.fs
+++ b/Fable.Remoting.Client/Http.fs
@@ -2,7 +2,6 @@ namespace Fable.Remoting.Client
 
 open Browser
 open Browser.Types
-open Fable.Core
 open Fable.Core.JsInterop
 
 module Http =
@@ -80,7 +79,7 @@ module Http =
             | Empty -> xhr.send()
             | RequestBody.Json content -> xhr.send(content)
             | Multipart blobs ->
-                let form = emitJsExpr () "new FormData()"
+                let form = InternalUtilities.createFormData ()
 
                 for i in 0 .. blobs.Length - 1 do
                     form?append (i.ToString (), blobs.[i])


### PR DESCRIPTION
There have been some changes in newer Browser binding package versions, and `Browser.XMLHttpRequest.FormData.Create` no longer compiles. Let's just use a bit of dynamic typing.