### PR TITLE
Binary request serialization

### DIFF
--- a/ClientTests/src/App.fs
+++ b/ClientTests/src/App.fs
@@ -14,6 +14,7 @@ let server =
     Remoting.createApi()
     |> Remoting.withRouteBuilder routeBuilder
     |> Remoting.withMultipartOptimization
+    |> Remoting.withBinaryRequestSerialization
     |> Remoting.buildProxy<IServer>
 
 let binaryServer =
@@ -1819,6 +1820,9 @@ let msgPackTests =
             -5y |> serializeDeserializeCompare typeof<sbyte>
             [| 0uy; 255uy; 100uy; 5uy |] |> serializeDeserializeCompare typeof<byte[]>
             [| 0y; 100y; -100y; -5y |] |> serializeDeserializeCompare typeof<sbyte[]>
+
+        testCase "Nested anonymous" <| fun () ->
+            Just {| nested  = {| name = "John" |} |} |> serializeDeserializeCompare typeof<Maybe<{| nested: {| name: string |} |}>>
 
 #if NAGAREYAMA
         testCase "DateOnlyMap" <| fun () ->

--- a/Fable.Remoting.Client/Http.fs
+++ b/Fable.Remoting.Client/Http.fs
@@ -78,6 +78,7 @@ module Http =
             match req.RequestBody with
             | Empty -> xhr.send()
             | RequestBody.Json content -> xhr.send(content)
+            | MsgPack bytes -> xhr.send bytes
             | Multipart blobs ->
                 let form = InternalUtilities.createFormData ()
 

--- a/Fable.Remoting.Client/Remoting.fs
+++ b/Fable.Remoting.Client/Remoting.fs
@@ -15,6 +15,7 @@ module Remoting =
         WithCredentials = false
         RouteBuilder = sprintf ("/%s/%s")
         CustomResponseSerialization = None
+        CustomRequestSerialization = None
         IsMultipartEnabled = false
     }
 
@@ -43,6 +44,23 @@ module Remoting =
         let serializer response returnType = MsgPack.Read.Reader(response).Read returnType
         { options with CustomResponseSerialization = Some serializer }
 
+    /// Specifies that the API uses binary serialization for requests
+    let withBinaryRequestSerialization (options: RemoteBuilderOptions) =
+        let serializer (requestArgs: obj[]) (requestTypes: Type[]) =
+            let out = ResizeArray ()
+
+            if requestArgs.Length = 1 then
+                MsgPack.Write.Fable.writeObject requestArgs.[0] requestTypes.[0] out
+            else
+                MsgPack.Write.Fable.writeArrayHeader requestArgs.Length out
+
+                for i in 0 .. requestArgs.Length - 1 do
+                    MsgPack.Write.Fable.writeObject requestArgs.[i] requestTypes.[i] out
+
+            out
+
+        { options with CustomRequestSerialization = Some serializer }
+
     /// Enables top level byte array parameters (such as in `upload: Metadata -> byte[] -> Async<UploadResult>`) to be sent with minimal overhead using multipart/form-data.
     ///
     /// !!! Fable.Remoting.Suave servers do not support this option.
@@ -51,57 +69,49 @@ module Remoting =
 type Remoting() =
     /// For internal library use only.
     static member buildProxy(options: RemoteBuilderOptions, resolvedType: Type) =
-        let schemaType = createTypeInfo resolvedType
-        match schemaType with
-        | TypeInfo.Record getFields ->
-            let (fields, recordType) = getFields()
-            let fieldTypes = Reflection.FSharpType.GetRecordFields recordType |> Array.map (fun prop -> prop.Name, prop.PropertyType)
-            let recordFields = [|
-                for field in fields do
-                    let normalize n =
-                        let fieldType = fieldTypes |> Array.pick (fun (name, typ) -> if name = field.FieldName then Some typ else None)
-                        let fn = Proxy.proxyFetch options recordType.Name field fieldType
-                        match n with
-                        | 0 -> box (fn null null null null null null null null)
-                        | 1 -> box (fun a ->
-                            fn a null null null null null null null)
-                        | 2 ->
-                            let proxyF a b = fn a b null null null null null null
-                            unbox (System.Func<_,_,_> proxyF)
-                        | 3 ->
-                            let proxyF a b c = fn a b c null null null null null
-                            unbox (System.Func<_,_,_,_> proxyF)
-                        | 4 ->
-                            let proxyF a b c d = fn a b c d null null null null
-                            unbox (System.Func<_,_,_,_,_> proxyF)
-                        | 5 ->
-                            let proxyF a b c d e = fn a b c d e null null null
-                            unbox (System.Func<_,_,_,_,_,_> proxyF)
-                        | 6 ->
-                            let proxyF a b c d e f = fn a b c d e f null null
-                            unbox (System.Func<_,_,_,_,_,_,_> proxyF)
-                        | 7 ->
-                            let proxyF a b c d e f g = fn a b c d e f g null
-                            unbox (System.Func<_,_,_,_,_,_,_,_> proxyF)
-                        | 8 ->
-                            let proxyF a b c d e f g h = fn a b c d e f g h
-                            unbox (System.Func<_,_,_,_,_,_,_,_,_> proxyF)
-                        | _ ->
-                            failwithf "Cannot generate proxy function for %s. Only up to 8 arguments are supported. Consider using a record type as input" field.FieldName
+        if Reflection.FSharpType.IsRecord resolvedType then
+            let recordFields =
+                Reflection.FSharpType.GetRecordFields resolvedType
+                |> Array.map (fun prop ->
+                    let fieldTypeInfo = createTypeInfo prop.PropertyType
+                    let fn = Proxy.proxyFetch options resolvedType.Name { PropertyInfo = prop; FieldName = prop.Name; FieldType = fieldTypeInfo } prop.PropertyType
 
                     let argumentCount =
-                        match field.FieldType with
-                        | TypeInfo.Async _  -> 0
-                        | TypeInfo.Promise _  -> 0
+                        match fieldTypeInfo with
                         | TypeInfo.Func getArgs -> Array.length (getArgs()) - 1
                         | _ -> 0
 
-                    normalize argumentCount
-                |]
+                    match argumentCount with
+                    | 0 -> box (fn null null null null null null null null)
+                    | 1 -> box (fun a ->
+                        fn a null null null null null null null)
+                    | 2 ->
+                        let proxyF a b = fn a b null null null null null null
+                        unbox (System.Func<_,_,_> proxyF)
+                    | 3 ->
+                        let proxyF a b c = fn a b c null null null null null
+                        unbox (System.Func<_,_,_,_> proxyF)
+                    | 4 ->
+                        let proxyF a b c d = fn a b c d null null null null
+                        unbox (System.Func<_,_,_,_,_> proxyF)
+                    | 5 ->
+                        let proxyF a b c d e = fn a b c d e null null null
+                        unbox (System.Func<_,_,_,_,_,_> proxyF)
+                    | 6 ->
+                        let proxyF a b c d e f = fn a b c d e f null null
+                        unbox (System.Func<_,_,_,_,_,_,_> proxyF)
+                    | 7 ->
+                        let proxyF a b c d e f g = fn a b c d e f g null
+                        unbox (System.Func<_,_,_,_,_,_,_,_> proxyF)
+                    | 8 ->
+                        let proxyF a b c d e f g h = fn a b c d e f g h
+                        unbox (System.Func<_,_,_,_,_,_,_,_,_> proxyF)
+                    | _ ->
+                        failwithf "Cannot generate proxy function for %s. Only up to 8 arguments are supported. Consider using a record type as input" prop.Name
+                )
 
-            let proxy = FSharpValue.MakeRecord(recordType, recordFields)
-            unbox proxy
-        | _ ->
+            FSharpValue.MakeRecord(resolvedType, recordFields) |> unbox
+        else
             failwithf "Cannot build proxy. Exepected type %s to be a valid protocol definition which is a record of functions" resolvedType.FullName
 
     static member inline buildProxy<'t>(options: RemoteBuilderOptions) : 't =

--- a/Fable.Remoting.Client/Types.fs
+++ b/Fable.Remoting.Client/Types.fs
@@ -7,6 +7,7 @@ type HttpMethod = GET | POST
 type RequestBody = 
     | Empty
     | Json of string
+    | MsgPack of byte[]
     | Multipart of Browser.Types.Blob[]
 
 type CustomResponseSerializer = byte[] -> Type -> obj
@@ -31,6 +32,7 @@ type RemoteBuilderOptions = {
     WithCredentials: bool
     RouteBuilder: (string -> string -> string)
     CustomResponseSerialization: CustomResponseSerializer option
+    CustomRequestSerialization: (obj[] -> Type[] -> ResizeArray<byte>) option
     IsMultipartEnabled: bool
 }
 

--- a/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
+++ b/Fable.Remoting.DotnetClient/Fable.Remoting.DotnetClient.fsproj
@@ -8,7 +8,7 @@
         <PackageTags>fsharp;fable;remoting;rpc;webserver;json</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>3.36.0</Version>
-        <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Implement multipart requests</PackageReleaseNotes>
     </PropertyGroup>

--- a/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
+++ b/Fable.Remoting.MsgPack.Tests/FableConverterTests.fs
@@ -236,6 +236,9 @@ let converterTest =
             [ Just 4; Nothing ] |> serializeDeserializeCompare
             [ Just 4; Nothing ] |> serializeDeserializeCompare
         }
+        test "Nested anonymous" {
+            Just {| nested  = {| name = "John" |} |} |> serializeDeserializeCompare
+        }
         test "null string" {
             (null: string) |> serializeDeserializeCompare
         }

--- a/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
+++ b/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
@@ -11,7 +11,7 @@
     <Version>1.24.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Fix serialization bug in latest Fable compiler</PackageReleaseNotes>
-    <TargetFrameworks>netstandard2.0;net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TypeShape.fs" />

--- a/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
+++ b/Fable.Remoting.Server/Fable.Remoting.Server.fsproj
@@ -10,7 +10,7 @@
         <Authors>Zaid Ajaj;Diego Esmerio</Authors>
         <Version>5.41.0</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <PackageReleaseNotes>Implement multipart requests</PackageReleaseNotes>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/Fable.Remoting.Server/Proxy.fs
+++ b/Fable.Remoting.Server/Proxy.fs
@@ -159,6 +159,9 @@ let rec private makeEndpointProxy<'fieldPart> (makeProps: MakeEndpointProps): 'f
                         | Choice3Of3 json :: t ->
                             let inp = json.ToObject<'inp> fableSerializer
                             outp (f inp) { props with Arguments = t }
+                        | [] when typeof<'inp> = typeof<unit> ->
+                            let inp = Unchecked.defaultof<'inp>
+                            outp (f inp) { props with Arguments = [] }
                         | [] ->
                             let typeInfo = typeNames makeProps.FlattenedTypes.[ 0 .. makeProps.FlattenedTypes.Length - 2]
                             failwithf "The record function '%s' expected %d argument(s) of the types %s but got %d argument(s) in the input" makeProps.FieldName (makeProps.FlattenedTypes.Length - 1) typeInfo props.Arguments.Length)

--- a/Fable.Remoting.Server/Proxy.fs
+++ b/Fable.Remoting.Server/Proxy.fs
@@ -71,12 +71,16 @@ let private readMultipartArgs props options = task {
             if section.ContentType.Equals ("application/octet-stream", StringComparison.Ordinal) then
                 use buffer = (getRecyclableMemoryStreamManager options).GetStream "remoting-input-multipart"
                 do! section.Body.CopyToAsync buffer
-                parts.Add (buffer.GetReadOnlySequence().ToArray () |> Choice1Of2)
+                parts.Add (buffer.GetReadOnlySequence().ToArray () |> Choice1Of3)
+            elif section.ContentType.Equals ("application/vnd.msgpack", StringComparison.Ordinal) then
+                use buffer = (getRecyclableMemoryStreamManager options).GetStream "remoting-input-multipart"
+                do! section.Body.CopyToAsync buffer
+                parts.Add (buffer.GetReadOnlySequence().ToArray () |> Choice2Of3)
             else
                 use sr = new StreamReader (section.Body)
                 let! text = sr.ReadToEndAsync ()
                 let token = JsonConvert.DeserializeObject<JToken> (text, settings)
-                parts.Add (Choice2Of2 token)
+                parts.Add (Choice3Of3 token)
 
     return Seq.toList parts
 }
@@ -138,18 +142,23 @@ let rec private makeEndpointProxy<'fieldPart> (makeProps: MakeEndpointProps): 'f
 
                     wrap (fun (f: 'inp -> 'out) props ->
                         match props.Arguments with
-                        | Choice1Of2 bytes :: t ->
+                        | Choice1Of3 bytes :: t ->
                             if typeof<'inp> <> typeof<byte[]> then
                                 failwithf "The record function '%s' expected an argument of type %s, but got binary input" makeProps.FieldName typeof<'inp>.Name
 
                             let inp = box bytes :?> 'inp
                             outp (f inp) { props with Arguments = t }
-                        | Choice2Of2 json :: t ->
+                        | Choice2Of3 bytes :: t ->
+                            let inp =
+                                if typeof<'inp> = typeof<unit> then
+                                    Unchecked.defaultof<'inp>
+                                else
+                                    MsgPack.Read.Reader(bytes).Read typeof<'inp> :?> 'inp
+
+                            outp (f inp) { props with Arguments = t }
+                        | Choice3Of3 json :: t ->
                             let inp = json.ToObject<'inp> fableSerializer
                             outp (f inp) { props with Arguments = t }
-                        | [] when typeof<'inp> = typeof<unit> ->
-                            let inp = box () :?> _
-                            outp (f inp) { props with Arguments = [] }
                         | [] ->
                             let typeInfo = typeNames makeProps.FlattenedTypes.[ 0 .. makeProps.FlattenedTypes.Length - 2]
                             failwithf "The record function '%s' expected %d argument(s) of the types %s but got %d argument(s) in the input" makeProps.FieldName (makeProps.FlattenedTypes.Length - 1) typeInfo props.Arguments.Length)
@@ -172,9 +181,17 @@ let makeApiProxy<'impl, 'ctx> (options: RemotingOptions<'ctx, 'impl>): Invocatio
                     try
                         if not (props.HttpVerb.Equals ("POST", StringComparison.OrdinalIgnoreCase)) && not (isNoArg && props.HttpVerb.Equals ("GET", StringComparison.OrdinalIgnoreCase)) then
                             return InvalidHttpVerb
+                        elif isNoArg then
+                            let props' = { Arguments = []; IsProxyHeaderPresent = props.IsProxyHeaderPresent; Output = props.Output }
+                            return! fieldProxy (props.ImplementationBuilder () |> shape.Get) props'
                         elif props.InputContentType.StartsWith ("multipart/form-data", StringComparison.Ordinal) then
                             let! args = readMultipartArgs props options
                             let props' = { Arguments = args; IsProxyHeaderPresent = props.IsProxyHeaderPresent; Output = props.Output }
+                            return! fieldProxy (props.ImplementationBuilder () |> shape.Get) props'
+                        elif props.InputContentType.Equals ("application/vnd.msgpack", StringComparison.Ordinal) then
+                            let ms = new MemoryStream ()
+                            do! props.Input.CopyToAsync ms
+                            let props' = { Arguments = [ Choice2Of3 (ms.ToArray ()) ]; IsProxyHeaderPresent = props.IsProxyHeaderPresent; Output = props.Output }
                             return! fieldProxy (props.ImplementationBuilder () |> shape.Get) props'
                         else
                             use sr = new StreamReader (props.Input)
@@ -191,7 +208,7 @@ let makeApiProxy<'impl, 'ctx> (options: RemotingOptions<'ctx, 'impl>): Invocatio
 
                                     token
                                     :?> JArray
-                                    |> Seq.map Choice2Of2
+                                    |> Seq.map Choice3Of3
                                     |> Seq.toList
 
                             let props' = { Arguments = args; IsProxyHeaderPresent = props.IsProxyHeaderPresent; Output = props.Output }

--- a/Fable.Remoting.Server/Types.fs
+++ b/Fable.Remoting.Server/Types.fs
@@ -59,7 +59,7 @@ type internal ShapeFSharpAsyncOrTask<'T> () =
         member _.Element = shapeof<'T> :> _
 
 type internal InvocationPropsInt = {
-    Arguments: Choice<byte[], JToken> list
+    Arguments: Choice<byte[], byte[], JToken> list
     IsProxyHeaderPresent: bool
     Output: Stream
 }


### PR DESCRIPTION
A dirty but working POC for #297.

I think the API surface is due for some cleanup, so a major version bump would probably be best. Ideally the request serialization format should be pluggable (maybe even completely custom, provided by the user?) for maximum tree-shakability. Right now if I switch to MsgPack in Fable.Remoting.Client, Fable.SimpleJson, Parsimmon, etc. will still land in the bundle, even though MsgPack does not need any of them to serialize requests and deserialize responses.

I'll let the PR simmer for now.

note to self: DotnetClient with MsgPack serialization won't work on iOS