### PR TITLE
Fix: Turkish locale breaks discriminated union deserialization

### DIFF
--- a/Fable.Remoting.MsgPack/TypeShape.fs
+++ b/Fable.Remoting.MsgPack/TypeShape.fs
@@ -1057,7 +1057,7 @@ type [<Sealed>] ShapeFSharpUnionCase<'Union> private (uci : UnionCaseInfo) =
             let underlyingType = properties.[0].DeclaringType
             let allFields = underlyingType.GetFields(AllInstanceMembers)
             let mkUnionField (p : PropertyInfo) =
-                let fieldInfo = allFields |> Array.find (fun f -> f.Name = "_" + p.Name || f.Name.ToLower() = p.Name.ToLower())
+                let fieldInfo = allFields |> Array.find (fun f -> f.Name = "_" + p.Name || f.Name.ToLowerInvariant() = p.Name.ToLowerInvariant())
                 mkWriteMemberUntyped<'Union> p.Name p [|fieldInfo|]
 
             Array.map mkUnionField properties


### PR DESCRIPTION
Adds a test case that reproduces the issue with discriminated union deserialization when the current culture is set to Turkish (tr-TR). The test demonstrates how culture-sensitive string comparisons in TypeShape can cause union case name matching to fail.

The test sets the thread's CurrentCulture and CurrentUICulture to Turkish before running the test cases and restores the original culture afterward.