### PR TITLE
Add a fable remoting adapter for the Falco framework

### DIFF
--- a/Fable.Remoting.Falco.Tests/App.fs
+++ b/Fable.Remoting.Falco.Tests/App.fs
@@ -1,0 +1,10 @@
+module Program
+
+open Expecto
+open Expecto.Logging
+
+open FableFalcoAdapterTests
+let testConfig =  { defaultConfig with verbosity = Debug }
+
+[<EntryPoint>]
+let main _ = runTests testConfig fableFalcoAdapterTests

--- a/Fable.Remoting.Falco.Tests/Fable.Remoting.Falco.Tests.fsproj
+++ b/Fable.Remoting.Falco.Tests/Fable.Remoting.Falco.Tests.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Fable.Remoting.Json\Fable.Remoting.Json.fsproj" />
+        <ProjectReference Include="..\Fable.Remoting.Server\Fable.Remoting.Server.fsproj" />
+        <ProjectReference Include="..\Fable.Remoting.Falco\Fable.Remoting.Falco.fsproj" />
+        <ProjectReference Include="..\Fable.Remoting.DotnetClient\Fable.Remoting.DotnetClient.fsproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="Types.fs" />
+      <Compile Include="FableFalcoAdapterTests.fs" />
+      <Compile Include="App.fs" />
+    </ItemGroup>
+
+    <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/Fable.Remoting.Falco.Tests/FableFalcoAdapterTests.fs
+++ b/Fable.Remoting.Falco.Tests/FableFalcoAdapterTests.fs
@@ -1,0 +1,708 @@
+﻿module FableFalcoAdapterTests
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.TestHost
+open Microsoft.AspNetCore.Http
+
+
+open Expecto
+open Types
+open System.Net
+open Microsoft.IO
+
+let builder = sprintf "/api/%s/%s"
+
+module ServerParts =
+
+    open Falco
+    open Microsoft.Extensions.DependencyInjection
+    open Fable.Remoting.Server
+    open Fable.Remoting.Falco
+    let webApp =
+        Remoting.createApi()
+        |> Remoting.withRouteBuilder builder
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
+        |> Remoting.fromValue server
+        |> Remoting.buildHttpEndpoints
+        
+
+    let webAppBinary =
+        Remoting.createApi()
+        |> Remoting.withRouteBuilder builder
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
+        |> Remoting.withBinarySerialization
+        |> Remoting.withRecyclableMemoryStreamManager (RecyclableMemoryStreamManager (RecyclableMemoryStreamManager.Options (ThrowExceptionOnToArray = true)))
+        |> Remoting.fromValue binaryServer
+        |> Remoting.buildHttpEndpoints
+
+    let otherWebApp =
+        Remoting.createApi()
+        |> Remoting.withRouteBuilder builder
+        |> Remoting.withErrorHandler (fun ex routeInfo -> Propagate (sprintf "Message: %s, request body: %A" ex.Message routeInfo.requestBodyText))
+        |> Remoting.fromContext (fun ctx -> implementation)
+        |> Remoting.buildHttpEndpoints
+
+    let configureServices (services : IServiceCollection) =
+        services.AddRouting() |> ignore
+    let configureApp (app : IApplicationBuilder) =
+        let endpoints = Seq.collect id [webApp; webAppBinary; otherWebApp]
+        app.UseRouting().UseFalco endpoints |> ignore
+
+    let createHost() =
+        WebHostBuilder()
+            .UseContentRoot(Directory.GetCurrentDirectory())
+            .ConfigureServices(Action<IServiceCollection> configureServices)
+            .Configure(Action<IApplicationBuilder> configureApp)
+            
+open ServerParts
+
+let testServer = new TestServer(createHost())
+let client = testServer.CreateClient()
+
+module ClientParts =
+    open Fable.Remoting.DotnetClient
+
+    // proxies to different API's
+    let proxy = Proxy.custom<IServer> builder client false
+    let binaryProxy = Proxy.custom<IBinaryServer> builder client true
+    let protocolProxy = Proxy.custom<IProtocol> builder client false
+
+open ClientParts
+
+let fableFalcoAdapterTests =
+    testList "FableFalcoAdapter tests" [
+        
+        testCaseAsync "IProtocol.echoGenericUnionInt" <| async {
+            let! result = protocolProxy.call(fun server -> server.echoGenericUnionInt (Just 5))
+            Expect.equal (Just 5) result "it works"
+        }
+
+        testCaseAsync "IProtocol.binaryContent" <| async {
+            let! result = protocolProxy.call(fun server -> server.binaryContent())
+            Expect.equal [| 1uy; 2uy; 3uy |] result "it works"
+        }
+
+        testCaseAsync "IServer.getLength" <| async {
+            let! result =  proxy.call(fun server -> server.getLength "hello")
+            Expect.equal 5 result "Length returned is correct"
+        }
+
+        testCaseAsync "IProtocol.echoIntList" <| async {
+            let input =  [1 .. 5]
+            let! result = protocolProxy.call(fun server -> server.echoIntList input)
+            Expect.equal [1 .. 5] result "it works"
+        }
+
+        testCaseAsync "IServer.getLength expression from outside" <| async {
+            let value = "value from outside"
+            let! result =  proxy.call(fun server -> server.getLength value)
+            Expect.equal 18 result "Length returned is correct"
+        }
+
+        testCaseAsync "IServer.echoInteger" <| async {
+            let! firstResult = proxy.call (fun server -> server.echoInteger 20)
+            let! secondResult = proxy.call (fun server -> server.echoInteger 0)
+            Expect.equal 20 firstResult "result is echoed correctly"
+            Expect.equal 0 secondResult "result is echoed correctly"
+        }
+
+        testCaseAsync "IServer.echoInteger with explicit quotes" <| async {
+            let! firstResult = proxy.call <@ fun (server: IServer) -> server.echoInteger 20 @>
+            let! secondResult = proxy.call <@ fun (server: IServer) -> server.echoInteger 0 @>
+            Expect.equal 20 firstResult "result is echoed correctly"
+            Expect.equal 0 secondResult "result is echoed correctly"
+        }
+
+        testCaseAsync "IServer.simpleUnit" <| async {
+            let! result =  proxy.call (fun server -> server.simpleUnit ())
+            Expect.equal 42 result "result is correct"
+        }
+
+        testCaseAsync "IServer.echoBool" <| async {
+            let! one = proxy.call (fun server -> server.echoBool true)
+            let! two = proxy.call (fun server -> server.echoBool false)
+            Expect.equal one true "Bool result is correct"
+            Expect.equal two false "Bool result is correct"
+        }
+
+        testCaseAsync "IServer.echoIntOption" <| async {
+            let! one =  proxy.call (fun server -> server.echoIntOption (Some 20))
+            let! two =  proxy.call (fun server -> server.echoIntOption None)
+
+            Expect.equal one (Some 20) "Option<int> returned is correct"
+            Expect.equal two None "Option<int> returned is correct"
+        }
+
+        testCaseAsync "IServer.echoIntOption from outside" <| async {
+            let first = Some 20
+            let second : Option<int> = None
+            let! one =  proxy.call (fun server -> server.echoIntOption first)
+            let! two =  proxy.call (fun server -> server.echoIntOption second)
+
+            Expect.equal one (Some 20) "Option<int> returned is correct"
+            Expect.equal two None "Option<int> returned is correct"
+        }
+
+        testCaseAsync "IServer.echoStringOption" <| async {
+            let! one = proxy.call (fun server -> server.echoStringOption (Some "value"))
+            let! two = proxy.call (fun server -> server.echoStringOption None)
+            Expect.equal one (Some "value") "Option<string> returned is correct"
+            Expect.equal two None "Option<string> returned is correct"
+        }
+
+        testCaseAsync "IServer.echoStringOption from outside" <| async {
+            let first = Some "value"
+            let second : Option<string> = None
+            let! one = proxy.call (fun server -> server.echoStringOption first)
+            let! two = proxy.call (fun server -> server.echoStringOption second)
+            Expect.equal one (Some "value") "Option<string> returned is correct"
+            Expect.equal two None "Option<string> returned is correct"
+        }
+
+        testCaseAsync "IServer.echoSimpleUnionType" <| async {
+            let! result1 = proxy.call (fun server -> server.echoSimpleUnionType One)
+            let! result2 = proxy.call (fun server -> server.echoSimpleUnionType Two)
+            Expect.equal true (result1 = One) "SimpleUnion returned is correct"
+            Expect.equal true (result2 = Two) "SimpleUnion returned is correct"
+        }
+
+        testCaseAsync "IServer.echoSimpleUnionType from outside" <| async {
+            let first = One
+            let second = Two
+            let! result1 = proxy.call (fun server -> server.echoSimpleUnionType first)
+            let! result2 = proxy.call (fun server -> server.echoSimpleUnionType second)
+            Expect.equal true (result1 = One) "SimpleUnion returned is correct"
+            Expect.equal true (result2 = Two) "SimpleUnion returned is correct"
+        }
+
+        testCaseAsync "IServer.echoGenericUnionInt" <| async {
+            let! result1 = proxy.call (fun server -> server.echoGenericUnionInt (Just 5))
+            let! result2 = proxy.call (fun server -> server.echoGenericUnionInt (Just 10))
+            let! result3 = proxy.call (fun server -> server.echoGenericUnionInt Nothing)
+
+            Expect.equal true (result1 = Just 5) "GenericUnionInt returned is correct"
+            Expect.equal true (result2 = Just 10) "GenericUnionInt returned is correct"
+            Expect.equal true (result3 = Nothing) "GenericUnionInt returned is correct"
+        }
+
+        testCaseAsync "IServer.echoGenericUnionString" <| async {
+            let! result1 = proxy.call (fun server -> server.echoGenericUnionString (Just ""))
+            let! result2 = proxy.call (fun server -> server.echoGenericUnionString (Just null))
+            let! result3 = proxy.call (fun server -> server.echoGenericUnionString Nothing)
+
+            Expect.equal true (result1 = Just "") "GenericUnionString returned is correct"
+            Expect.equal true (result2 = Just null) "GenericUnionString returned is correct"
+            Expect.equal true (result3 = Nothing) "GenericUnionString returned is correct"
+        }
+
+        testCaseAsync "IServer.echoRecord" <| async {
+            let record1 = { Prop1 = "hello"; Prop2 = 10; Prop3 = None }
+            let record2 = { Prop1 = ""; Prop2 = 20; Prop3 = Some 10 }
+            let record3 = { Prop1 = null; Prop2 = 30; Prop3 = Some 20  }
+            let! result1 = proxy.call ( fun server -> server.echoRecord record1 )
+            let! result2 = proxy.call ( fun server -> server.echoRecord record2 )
+            let! result3 = proxy.call ( fun server -> server.echoRecord record3 )
+
+            Expect.equal true (result1 = record1) "Record returned is correct"
+            Expect.equal true (result2 = record2) "Record returned is correct"
+            Expect.equal true (result3 = record3) "Record returned is correct"
+        }
+
+        testCaseAsync "IServer.echoNestedGeneric from outside" <| async {
+            let input : GenericRecord<Maybe<int option>> = {
+                Value = Just (Some 5)
+                OtherValue = 2
+            }
+
+            let input2 : GenericRecord<Maybe<int option>> = {
+                Value = Just (None)
+                OtherValue = 2
+            }
+
+            let! result1 = proxy.call ( fun server -> server.echoNestedGeneric input )
+            let! result2 = proxy.call ( fun server -> server.echoNestedGeneric input2 )
+            Expect.equal true (input = result1) "Nested generic record is correct"
+            Expect.equal true (input2 = result2) "Nested generic record is correct"
+        }
+
+        // Inline values cannot always be compiled, so define first and reference from inside the quotation expression
+        testCaseAsync "IServer.echoNestedGeneric inline in expression" <| async {
+            let! result1 = proxy.call ( fun server -> server.echoNestedGeneric { Value = Just (Some 5); OtherValue = 2 }  )
+            let! result2 = proxy.call ( fun server -> server.echoNestedGeneric { Value = Just (None); OtherValue = 2 } )
+            Expect.equal true ({ Value = Just (Some 5); OtherValue = 2 } = result1) "Nested generic record is correct"
+            Expect.equal true ({ Value = Just (None); OtherValue = 2 } = result2) "Nested generic record is correct"
+        }
+
+        testCaseAsync "IServer.echoIntList" <| async {
+            let inputList = [1 .. 5]
+            let! output = proxy.call ( fun server -> server.echoIntList inputList )
+            Expect.equal output [1;2;3;4;5] "The echoed list is correct"
+            let emptyList : int list = [ ]
+            let! echoedList = proxy.call ( fun server -> server.echoIntList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "The echoed list is correct"
+        }
+
+        testCaseAsync "IServer.echoSingleCase" <| async {
+            let! output = proxy.call ( fun server -> server.echoSingleCase (SingleCase 10) )
+            Expect.equal output (SingleCase 10) "Single case union roundtrip works"
+        }
+
+        testCaseAsync "IServer.echoStringList" <| async {
+            let input = ["one"; "two"; null]
+            let! output = proxy.call ( fun server -> server.echoStringList input )
+            Expect.equal input output "Echoed list is correct"
+            let emptyList : string list = []
+            let! echoedList = proxy.call ( fun server -> server.echoStringList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "Echoed list is empty"
+        }
+
+        testCaseAsync "IServer.echoBoolList" <| async {
+            let input = [true; false; true]
+            let! output = proxy.call ( fun server -> server.echoBoolList input )
+            Expect.equal output input "Echoed list is correct"
+            let emptyList : bool list = []
+            let! echoedList = proxy.call ( fun server -> server.echoBoolList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "Echoed list is empty"
+        }
+
+        testCaseAsync "IServer.echoListOfListsOfStrings" <| async {
+            let input = [["1"; "2"]; ["3"; "4";"5"]]
+            let! output = proxy.call ( fun server -> server.echoListOfListsOfStrings input )
+            Expect.equal input output "Echoed list is correct"
+        }
+
+        testCaseAsync "IServer.echoResult for Result<int, string>" <| async {
+            let! output = proxy.call ( fun server -> server.echoResult (Ok 15) )
+            Expect.equal output (Ok 15) "Result is correct"
+
+            let! output = proxy.call ( fun server -> server.echoResult (Result.Error "somewhere here") )
+            Expect.equal output (Error "somewhere here")  "Result is correct"
+        }
+
+        testCaseAsync "IServer.echoMap" <| async {
+            let input = ["hello", 1] |> Map.ofList
+            let! output = proxy.call ( fun server -> server.echoMap input )
+            Expect.equal input output "Map is echoed correctly"
+        }
+
+        (*
+            calling the function:
+            throwError = fun () -> async {
+                return! failwith "Generating custom server error"
+            }
+
+            with error handler: (fun ex routeInfo -> Propagate ex.Message)
+        *)
+        testCaseAsync "IServer.throwError using callSafely" <| async {
+            let! result = proxy.callSafely (fun server -> server.throwError())
+            match result with
+            | Ok value -> failwithf "Got value %A where an error was expected" value
+            | Result.Error ex ->
+                match ex with
+                | :? Fable.Remoting.DotnetClient.Http.ProxyRequestException as reqEx ->
+                    Expect.isTrue (reqEx.ResponseText.Contains("Generating custom server error")) "Works"
+                | other -> Expect.isTrue false "Should not happen"
+        }
+
+        testCaseAsync "IServer.throwError using callSafelyTask" <| async {
+            let! result = proxy.callSafelyTask (fun server -> server.throwError()) |> Async.AwaitTask
+            match result with
+            | Ok value -> failwithf "Got value %A where an error was expected" value
+            | Result.Error ex ->
+                match ex with
+                | :? Fable.Remoting.DotnetClient.Http.ProxyRequestException as reqEx ->
+                    Expect.isTrue (reqEx.ResponseText.Contains("Generating custom server error")) "Works"
+                | other -> Expect.isTrue false "Should not happen"
+        }
+
+        testCaseAsync "IServer.mutliArgFunc" <| async {
+            let! result = proxy.call (fun server -> server.multiArgFunc "hello" 10 false)
+            Expect.equal 15 result "Result is correct"
+
+            let! sndResult = proxy.call (fun server -> server.multiArgFunc "byebye" 5 true)
+            Expect.equal 12 sndResult "Result is correct"
+        }
+
+        testCaseAsync "IServer.pureAsync" <| async {
+            let! result = proxy.call (fun server -> server.pureAsync)
+            Expect.equal 42 result "Pure async without parameters works"
+        }
+
+        testCaseAsync "IServer.pureAsync as task" <| async {
+            let! result = proxy.callTask (fun server -> server.pureAsync) |> Async.AwaitTask
+            Expect.equal 42 result "Pure async without parameters works"
+        }
+
+        testCaseAsync "IServer.asyncNestedGeneric" <| async {
+            let! result = proxy.call (fun server -> server.asyncNestedGeneric)
+            Expect.equal { OtherValue = 10; Value = Just (Some "value") } result "Returned value is correct"
+        }
+
+        testCaseAsync "IServer.echoBigInteger" <| async {
+            let input = 1I
+            let! output = proxy.call (fun server -> server.echoBigInteger input)
+            Expect.equal input output "Big int is equal"
+        }
+
+        testCaseAsync "IServer.tuplesAndLists" <| async {
+            let inputDict = Map.ofList [ "hello", 5 ]
+            let inputStrings = [ "there!" ]
+            let! output = proxy.call (fun server -> server.tuplesAndLists (inputDict, inputStrings))
+            let expected = Map.ofList [ "hello", 5; "there!", 6 ]
+            Expect.equal output expected "Echoed map is correct"
+        }
+
+        let testDataTableWithProxyCall proxyCall = async {
+            let t = new System.Data.DataTable()
+            t.TableName <- "myname"
+            t.Columns.Add("a", typeof<int64>) |> ignore
+            t.Columns.Add("b", typeof<string>) |> ignore
+            t.Rows.Add(1L, "11111")  |> ignore
+            t.Rows.Add(2L, "222222") |> ignore
+
+            let! (deserialized: System.Data.DataTable) = proxyCall t
+
+            Expect.equal deserialized.TableName      t.TableName      "table name"
+            Expect.equal deserialized.Columns.Count  t.Columns.Count  "column count"
+            Expect.equal deserialized.Rows.Count     t.Rows.Count     "row count"
+            Expect.equal deserialized.Rows.[0].["a"] t.Rows.[0].["a"] "table.[0,'a']"
+            Expect.equal deserialized.Rows.[0].["b"] t.Rows.[0].["b"] "table.[0,'b']"
+            Expect.equal deserialized.Rows.[1].["a"] t.Rows.[1].["a"] "table.[1,'a']"
+            Expect.equal deserialized.Rows.[1].["b"] t.Rows.[1].["b"] "table.[1,'b']"
+        }
+
+        let testDataSetWithProxyCall proxyCall = async {
+            let t = new System.Data.DataTable()
+            t.TableName <- "myname"
+            t.Columns.Add("a", typeof<int64>) |> ignore
+            t.Columns.Add("b", typeof<string>) |> ignore
+            t.Rows.Add(1L, "11111")  |> ignore
+            t.Rows.Add(2L, "222222") |> ignore
+
+            let t2 = new System.Data.DataTable()
+            t2.TableName <- "myname2"
+            t2.Columns.Add("t.a", typeof<int64>) |> ignore
+            t2.Columns.Add("b", typeof<string>) |> ignore
+            t2.Constraints.Add(System.Data.ForeignKeyConstraint(t.Columns.["a"], t2.Columns.["t.a"], ConstraintName = "t2fk"))
+            t2.Rows.Add(1L, "t.11111")  |> ignore
+            t2.Rows.Add(2L, "t.222222") |> ignore
+
+            let ds = new System.Data.DataSet()
+            ds.Tables.Add t
+            ds.Tables.Add t2
+
+            let! (deserialized: System.Data.DataSet) = proxyCall ds
+
+            Expect.equal deserialized.Tables.Count                               ds.Tables.Count  "tables count"
+            Expect.equal deserialized.Tables.[0].TableName                       t.TableName      "table name"
+            Expect.equal deserialized.Tables.[0].Columns.Count                   t.Columns.Count  "column count"
+            Expect.equal deserialized.Tables.[0].Rows.Count                      t.Rows.Count     "row count"
+            Expect.equal deserialized.Tables.[0].Rows.[0].["a"]                  t.Rows.[0].["a"] "table.[0,'a']"
+            Expect.equal deserialized.Tables.[0].Rows.[0].["b"]                  t.Rows.[0].["b"] "table.[0,'b']"
+            Expect.equal deserialized.Tables.[0].Rows.[1].["a"]                  t.Rows.[1].["a"] "table.[1,'a']"
+            Expect.equal deserialized.Tables.[0].Rows.[1].["b"]                  t.Rows.[1].["b"] "table.[1,'b']"
+            Expect.equal deserialized.Tables.[1].Constraints.[0].ConstraintName "t2fk"            "constraint name"
+        }
+
+        testCaseAsync "IServer.echoDataTable" <| async {
+            let proxyCall = fun dt -> proxy.call (fun server -> server.echoDataTable dt)
+            do! testDataTableWithProxyCall proxyCall
+        }
+
+        testCaseAsync "IServer.echoDataSet" <| async {
+            let proxyCall = fun ds -> proxy.call (fun server -> server.echoDataSet ds)
+            do! testDataSetWithProxyCall proxyCall
+        }
+
+        testCaseAsync "IBinaryServer.getLength" <| async {
+            let! result =  binaryProxy.call(fun server -> server.getLength "hello")
+            Expect.equal 5 result "Length returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.getLength expression from outside" <| async {
+            let value = "value from outside"
+            let! result =  binaryProxy.call(fun server -> server.getLength value)
+            Expect.equal 18 result "Length returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoInteger" <| async {
+            let! firstResult = binaryProxy.call (fun server -> server.echoInteger 20)
+            let! secondResult = binaryProxy.call (fun server -> server.echoInteger 0)
+            Expect.equal 20 firstResult "result is echoed correctly"
+            Expect.equal 0 secondResult "result is echoed correctly"
+        }
+
+        testCaseAsync "IBinaryServer.echoInteger with explicit quotes" <| async {
+            let! firstResult = binaryProxy.call <@ fun server -> server.echoInteger 20 @>
+            let! secondResult = binaryProxy.call <@ fun server -> server.echoInteger 0 @>
+            Expect.equal 20 firstResult "result is echoed correctly"
+            Expect.equal 0 secondResult "result is echoed correctly"
+        }
+
+        testCaseAsync "IBinaryServer.simpleUnit" <| async {
+            let! result =  binaryProxy.call (fun server -> server.simpleUnit ())
+            Expect.equal 42 result "result is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoBool" <| async {
+            let! one = binaryProxy.call (fun server -> server.echoBool true)
+            let! two = binaryProxy.call (fun server -> server.echoBool false)
+            Expect.equal one true "Bool result is correct"
+            Expect.equal two false "Bool result is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoIntOption" <| async {
+            let! one =  binaryProxy.call (fun server -> server.echoIntOption (Some 20))
+            let! two =  binaryProxy.call (fun server -> server.echoIntOption None)
+
+            Expect.equal one (Some 20) "Option<int> returned is correct"
+            Expect.equal two None "Option<int> returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoIntOption from outside" <| async {
+            let first = Some 20
+            let second : Option<int> = None
+            let! one =  binaryProxy.call (fun server -> server.echoIntOption first)
+            let! two =  binaryProxy.call (fun server -> server.echoIntOption second)
+
+            Expect.equal one (Some 20) "Option<int> returned is correct"
+            Expect.equal two None "Option<int> returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoStringOption" <| async {
+            let! one = binaryProxy.call (fun server -> server.echoStringOption (Some "value"))
+            let! two = binaryProxy.call (fun server -> server.echoStringOption None)
+            Expect.equal one (Some "value") "Option<string> returned is correct"
+            Expect.equal two None "Option<string> returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoStringOption from outside" <| async {
+            let first = Some "value"
+            let second : Option<string> = None
+            let! one = binaryProxy.call (fun server -> server.echoStringOption first)
+            let! two = binaryProxy.call (fun server -> server.echoStringOption second)
+            Expect.equal one (Some "value") "Option<string> returned is correct"
+            Expect.equal two None "Option<string> returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoSimpleUnionType" <| async {
+            let! result1 = binaryProxy.call (fun server -> server.echoSimpleUnionType One)
+            let! result2 = binaryProxy.call (fun server -> server.echoSimpleUnionType Two)
+            Expect.equal true (result1 = One) "SimpleUnion returned is correct"
+            Expect.equal true (result2 = Two) "SimpleUnion returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoSimpleUnionType from outside" <| async {
+            let first = One
+            let second = Two
+            let! result1 = binaryProxy.call (fun server -> server.echoSimpleUnionType first)
+            let! result2 = binaryProxy.call (fun server -> server.echoSimpleUnionType second)
+            Expect.equal true (result1 = One) "SimpleUnion returned is correct"
+            Expect.equal true (result2 = Two) "SimpleUnion returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoGenericUnionInt" <| async {
+            let! result1 = binaryProxy.call (fun server -> server.echoGenericUnionInt (Just 5))
+            let! result2 = binaryProxy.call (fun server -> server.echoGenericUnionInt (Just 10))
+            let! result3 = binaryProxy.call (fun server -> server.echoGenericUnionInt Nothing)
+
+            Expect.equal true (result1 = Just 5) "GenericUnionInt returned is correct"
+            Expect.equal true (result2 = Just 10) "GenericUnionInt returned is correct"
+            Expect.equal true (result3 = Nothing) "GenericUnionInt returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoGenericUnionString" <| async {
+            let! result1 = binaryProxy.call (fun server -> server.echoGenericUnionString (Just ""))
+            let! result2 = binaryProxy.call (fun server -> server.echoGenericUnionString (Just null))
+            let! result3 = binaryProxy.call (fun server -> server.echoGenericUnionString Nothing)
+
+            Expect.equal true (result1 = Just "") "GenericUnionString returned is correct"
+            Expect.equal true (result2 = Just null) "GenericUnionString returned is correct"
+            Expect.equal true (result3 = Nothing) "GenericUnionString returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoRecord" <| async {
+            let record1 = { Prop1 = "hello"; Prop2 = 10; Prop3 = None }
+            let record2 = { Prop1 = ""; Prop2 = 20; Prop3 = Some 10 }
+            let record3 = { Prop1 = null; Prop2 = 30; Prop3 = Some 20  }
+            let! result1 = binaryProxy.call ( fun server -> server.echoRecord record1 )
+            let! result2 = binaryProxy.call ( fun server -> server.echoRecord record2 )
+            let! result3 = binaryProxy.call ( fun server -> server.echoRecord record3 )
+
+            Expect.equal true (result1 = record1) "Record returned is correct"
+            Expect.equal true (result2 = record2) "Record returned is correct"
+            Expect.equal true (result3 = record3) "Record returned is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoNestedGeneric from outside" <| async {
+            let input : GenericRecord<Maybe<int option>> = {
+                Value = Just (Some 5)
+                OtherValue = 2
+            }
+
+            let input2 : GenericRecord<Maybe<int option>> = {
+                Value = Just (None)
+                OtherValue = 2
+            }
+
+            let! result1 = binaryProxy.call ( fun server -> server.echoNestedGeneric input )
+            let! result2 = binaryProxy.call ( fun server -> server.echoNestedGeneric input2 )
+            Expect.equal true (input = result1) "Nested generic record is correct"
+            Expect.equal true (input2 = result2) "Nested generic record is correct"
+        }
+
+        // Inline values cannot always be compiled, so define first and reference from inside the quotation expression
+        testCaseAsync "IBinaryServer.echoNestedGeneric inline in expression" <| async {
+            let! result1 = binaryProxy.call ( fun server -> server.echoNestedGeneric { Value = Just (Some 5); OtherValue = 2 }  )
+            let! result2 = binaryProxy.call ( fun server -> server.echoNestedGeneric { Value = Just (None); OtherValue = 2 } )
+            Expect.equal true ({ Value = Just (Some 5); OtherValue = 2 } = result1) "Nested generic record is correct"
+            Expect.equal true ({ Value = Just (None); OtherValue = 2 } = result2) "Nested generic record is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoIntList" <| async {
+            let inputList = [1 .. 5]
+            let! output = binaryProxy.call ( fun server -> server.echoIntList inputList )
+            Expect.equal output [1;2;3;4;5] "The echoed list is correct"
+            let emptyList : int list = [ ]
+            let! echoedList = binaryProxy.call ( fun server -> server.echoIntList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "The echoed list is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoSingleCase" <| async {
+            let! output = binaryProxy.call ( fun server -> server.echoSingleCase (SingleCase 10) )
+            Expect.equal output (SingleCase 10) "Single case union roundtrip works"
+        }
+
+        testCaseAsync "IBinaryServer.echoStringList" <| async {
+            let input = ["one"; "two"; null]
+            let! output = binaryProxy.call ( fun server -> server.echoStringList input )
+            Expect.equal input output "Echoed list is correct"
+            let emptyList : string list = []
+            let! echoedList = binaryProxy.call ( fun server -> server.echoStringList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "Echoed list is empty"
+        }
+
+        testCaseAsync "IBinaryServer.echoBoolList" <| async {
+            let input = [true; false; true]
+            let! output = binaryProxy.call ( fun server -> server.echoBoolList input )
+            Expect.equal output input "Echoed list is correct"
+            let emptyList : bool list = []
+            let! echoedList = binaryProxy.call ( fun server -> server.echoBoolList emptyList )
+            Expect.equal true (List.isEmpty echoedList) "Echoed list is empty"
+        }
+
+        testCaseAsync "IBinaryServer.echoListOfListsOfStrings" <| async {
+            let input = [["1"; "2"]; ["3"; "4";"5"]]
+            let! output = binaryProxy.call ( fun server -> server.echoListOfListsOfStrings input )
+            Expect.equal input output "Echoed list is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoResult for Result<int, string>" <| async {
+            let! output = binaryProxy.call ( fun server -> server.echoResult (Ok 15) )
+            Expect.equal output (Ok 15) "Result is correct"
+
+            let! output = binaryProxy.call ( fun server -> server.echoResult (Result.Error "somewhere here") )
+            Expect.equal output (Error "somewhere here")  "Result is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoMap" <| async {
+            let input = ["hello", 1] |> Map.ofList
+            let! output = binaryProxy.call ( fun server -> server.echoMap input )
+            Expect.equal input output "Map is echoed correctly"
+        }
+
+        testCaseAsync "IBinaryServer.mutliArgFunc" <| async {
+            let! result = binaryProxy.call (fun server -> server.multiArgFunc "hello" 10 false)
+            Expect.equal 15 result "Result is correct"
+
+            let! sndResult = binaryProxy.call (fun server -> server.multiArgFunc "byebye" 5 true)
+            Expect.equal 12 sndResult "Result is correct"
+        }
+
+        testCaseAsync "IBinaryServer.pureAsync" <| async {
+            let! result = binaryProxy.call (fun server -> server.pureAsync)
+            Expect.equal 42 result "Pure async without parameters works"
+        }
+
+        testCaseAsync "IBinaryServer.asyncNestedGeneric" <| async {
+            let! result = binaryProxy.call (fun server -> server.asyncNestedGeneric)
+            Expect.equal { OtherValue = 10; Value = Just (Some "value") } result "Returned value is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoBigInteger" <| async {
+            let input = 1I
+            let! output = binaryProxy.call (fun server -> server.echoBigInteger input)
+            Expect.equal input output "Big int is equal"
+        }
+
+        testCaseAsync "IBinaryServer.echoBigInteger as task" <| async {
+            let input = 1I
+            let! output = binaryProxy.callTask (fun server -> server.echoBigInteger input) |> Async.AwaitTask
+            Expect.equal input output "Big int is equal"
+        }
+
+        testCaseAsync "IBinaryServer.tuplesAndLists" <| async {
+            let inputDict = Map.ofList [ "hello", 5 ]
+            let inputStrings = [ "there!" ]
+            let! output = binaryProxy.call (fun server -> server.tuplesAndLists (inputDict, inputStrings))
+            let expected = Map.ofList [ "hello", 5; "there!", 6 ]
+            Expect.equal output expected "Echoed map is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoDataTable" <| async {
+            let proxyCall = fun dt -> binaryProxy.call (fun server -> server.echoDataTable dt)
+            do! testDataTableWithProxyCall proxyCall
+        }
+
+        testCaseAsync "IBinaryServer.echoDataSet" <| async {
+            let proxyCall = fun ds -> binaryProxy.call (fun server -> server.echoDataSet ds)
+            do! testDataSetWithProxyCall proxyCall
+        }
+
+        testCaseAsync "IBinaryServer.pureTask as async" <| async {
+            let! output = binaryProxy.call (fun server -> server.pureTask)
+            Expect.equal output 42 "Pure task without parameters works"
+        }
+
+        testCaseAsync "IBinaryServer.pureTask as task" <| async {
+            let! output = binaryProxy.callTask (fun server -> server.pureTask) |> Async.AwaitTask
+            Expect.equal output 42 "Pure task without parameters works"
+        }
+
+        testCaseAsync "IBinaryServer.echoMapTask as async" <| async {
+            let expected = Map.ofList [ "yup", 6 ]
+            let! output = binaryProxy.call (fun server -> server.echoMapTask expected)
+            Expect.equal output expected "Echoed map is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoMapTask as task" <| async {
+            let expected = Map.ofList [ "yup", 6 ]
+            let! output = binaryProxy.callTask (fun server -> server.echoMapTask expected) |> Async.AwaitTask
+            Expect.equal output expected "Echoed map is correct"
+        }
+
+        testCaseAsync "IBinaryServer.pureTask as async with explicit quotes" <| async {
+            let! output = binaryProxy.call <@ fun server -> server.pureTask @>
+            Expect.equal output 42 "Pure task without parameters works"
+        }
+
+        testCaseAsync "IBinaryServer.pureTask as task with explicit quotes" <| async {
+            let! output = binaryProxy.callTask <@ fun server -> server.pureTask @> |> Async.AwaitTask
+            Expect.equal output 42 "Pure task without parameters works"
+        }
+
+        testCaseAsync "IBinaryServer.echoMapTask as async with explicit quotes" <| async {
+            let expected = Map.ofList [ "yup", 6 ]
+            let! output = binaryProxy.call <@ fun server -> server.echoMapTask expected @>
+            Expect.equal output expected "Echoed map is correct"
+        }
+
+        testCaseAsync "IBinaryServer.echoMapTask as task with explicit quotes" <| async {
+            let expected = Map.ofList [ "yup", 6 ]
+            let! output = binaryProxy.callTask <@ fun server -> server.echoMapTask expected @> |> Async.AwaitTask
+            Expect.equal output expected "Echoed map is correct"
+        }
+    ]

--- a/Fable.Remoting.Falco.Tests/Types.fs
+++ b/Fable.Remoting.Falco.Tests/Types.fs
@@ -1,0 +1,341 @@
+﻿module Types
+
+open System
+
+type Record = {
+    Prop1 : string
+    Prop2 : int
+    Prop3 : int option
+}
+
+type Maybe<'t> =
+    | Just of 't
+    | Nothing
+
+type AB = A | B
+
+type IProtocol = {
+    echoInteger : int -> Async<int>
+    echoMonth : DateTime -> Async<DateTime>
+    echoString : string -> Async<string>
+    echoIntOption : int option -> Async<int option>
+    echoStringOption : string option -> Async<string option>
+    echoGenericUnionInt : Maybe<int> -> Async<Maybe<int>>
+    echoGenericUnionString: Maybe<string> -> Async<Maybe<string>>
+    echoBool : bool -> Async<bool>
+    echoSimpleUnion : AB -> Async<AB>
+    echoRecord : Record -> Async<Record>
+        // binary responses
+    binaryContent : unit -> Async<byte[]>
+    binaryInputOutput : byte[] -> Async<byte[]>
+
+    echoIntList : int list -> Async<int list>
+    unitToInts : unit -> Async<int list>
+    echoRecordList : Record list -> Async<Record list>
+    floatList : float list -> Async<float list>
+    echoResult : Result<int, string> -> Async<Result<int, string>>
+    echoBigInteger : bigint -> Async<bigint>
+    echoMap : Map<string, int> -> Async<Map<string, int>>
+    echoTupleMap : Map<int*int, int> -> Async<Map<int*int, int>>
+
+}
+
+
+
+let pureAsync (x: 'a) : Async<'a> =
+    async { return x }
+
+let implementation = {
+    binaryContent = fun () -> async { return [| byte 1; byte 2; byte 3 |] }
+    binaryInputOutput = pureAsync
+    echoInteger = pureAsync
+    echoMonth = pureAsync
+    echoString = pureAsync
+    echoIntOption = pureAsync
+    echoGenericUnionInt = pureAsync
+    echoGenericUnionString = pureAsync
+    echoBool = pureAsync
+    echoStringOption = pureAsync
+    echoSimpleUnion = pureAsync
+    echoRecord = pureAsync
+    echoIntList = pureAsync
+    unitToInts = fun () -> pureAsync [1; 2; 3; 4; 5]
+    echoRecordList = pureAsync
+    floatList = pureAsync
+    echoResult = pureAsync
+    echoBigInteger = pureAsync
+    echoMap = pureAsync
+    echoTupleMap = pureAsync
+}
+
+
+open System
+open System.Threading.Tasks
+
+type UnionType = One | Two
+
+type GenericRecord<'t> = {
+    Value: 't
+    OtherValue : int
+}
+
+type SingleCase = SingleCase of int
+
+type SingleLongCase = SingleLongCase of int64
+
+type ISimpleServer = {
+    getLength : string -> Async<int>
+}
+
+type IServer = {
+    // primitive types
+    simpleUnit : unit -> Async<int>
+    getLength : string -> Async<int>
+    echoInteger : int -> Async<int>
+    echoString : string -> Async<string>
+    echoBool : bool -> Async<bool>
+    echoIntOption : int option -> Async<int option>
+    echoStringOption : string option -> Async<string option>
+
+    // Union types, simple and generic
+    echoGenericUnionInt : Maybe<int> -> Async<Maybe<int>>
+    echoGenericUnionString : Maybe<string> -> Async<Maybe<string>>
+    echoSimpleUnionType : UnionType -> Async<UnionType>
+
+    // Records, simple and generic
+    echoRecord : Record -> Async<Record>
+    echoGenericRecordInt : GenericRecord<int> -> Async<GenericRecord<int>>
+    echoNestedGeneric : GenericRecord<Maybe<int option>> -> Async<GenericRecord<Maybe<int option>>>
+
+    // lists
+    echoIntList : int list -> Async<int list>
+    echoStringList : string list -> Async<string list>
+    echoBoolList : bool list -> Async<bool list>
+    echoListOfListsOfStrings : string list list -> Async<string list list>
+    echoListOfGenericRecords :  GenericRecord<int> list -> Async<GenericRecord<int> list>
+
+    echoResult : Result<int, string> -> Async<Result<int, string>>
+    echoBigInteger : bigint -> Async<bigint>
+
+    // maps
+    echoMap : Map<string, int> -> Async<Map<string, int>>
+    // errors
+    throwError : unit -> Async<string>
+
+    echoSingleCase : SingleCase -> Async<SingleCase>
+    // mutli-arg functions
+    multiArgFunc : string -> int -> bool -> Async<int>
+
+    // tuples
+    tuplesAndLists : Map<string, int> * string list -> Async<Map<string, int>>
+    // overridden function
+    overriddenFunction : string -> Async<int>
+
+    customStatusCode : unit -> Async<string>
+    //Pure async
+    pureAsync : Async<int>
+    asyncNestedGeneric : Async<GenericRecord<Maybe<Option<string>>>>
+
+    // edge cases
+    multiArgComplex : bool -> GenericRecord<Maybe<Option<string>>> -> Async<GenericRecord<Maybe<Option<string>>>>
+
+    // long (int64) conversion
+    echoPrimitiveLong : int64 -> Async<int64>
+    echoComplexLong : GenericRecord<Int64> -> Async<GenericRecord<Int64>>
+    echoOptionalLong : Option<int64> -> Async<Option<int64>>
+    echoSingleDULong : SingleLongCase -> Async<SingleLongCase>
+    echoLongInGenericUnion : Maybe<int64> -> Async<Maybe<int64>>
+    echoDataTable : System.Data.DataTable -> Async<System.Data.DataTable>
+    echoDataSet : System.Data.DataSet -> Async<System.Data.DataSet>
+}
+
+type IBinaryServer = {
+    // primitive types
+    simpleUnit : unit -> Async<int>
+    getLength : string -> Async<int>
+    echoInteger : int -> Async<int>
+    echoString : string -> Async<string>
+    echoBool : bool -> Async<bool>
+    echoIntOption : int option -> Async<int option>
+    echoStringOption : string option -> Async<string option>
+
+    // Union types, simple and generic
+    echoGenericUnionInt : Maybe<int> -> Async<Maybe<int>>
+    echoGenericUnionString : Maybe<string> -> Async<Maybe<string>>
+    echoSimpleUnionType : UnionType -> Async<UnionType>
+
+    // Records, simple and generic
+    echoRecord : Record -> Async<Record>
+    echoGenericRecordInt : GenericRecord<int> -> Async<GenericRecord<int>>
+    echoNestedGeneric : GenericRecord<Maybe<int option>> -> Async<GenericRecord<Maybe<int option>>>
+
+    // lists
+    echoIntList : int list -> Async<int list>
+    echoStringList : string list -> Async<string list>
+    echoBoolList : bool list -> Async<bool list>
+    echoListOfListsOfStrings : string list list -> Async<string list list>
+    echoListOfGenericRecords :  GenericRecord<int> list -> Async<GenericRecord<int> list>
+
+    echoResult : Result<int, string> -> Async<Result<int, string>>
+    echoBigInteger : bigint -> Async<bigint>
+
+    // maps
+    echoMap : Map<string, int> -> Async<Map<string, int>>
+    // errors
+    throwError : unit -> Async<string>
+
+    echoSingleCase : SingleCase -> Async<SingleCase>
+    // mutli-arg functions
+    multiArgFunc : string -> int -> bool -> Async<int>
+
+    // tuples
+    tuplesAndLists : Map<string, int> * string list -> Async<Map<string, int>>
+    // overridden function
+    overriddenFunction : string -> Async<int>
+
+    customStatusCode : unit -> Async<string>
+    //Pure async
+    pureAsync : Async<int>
+    asyncNestedGeneric : Async<GenericRecord<Maybe<Option<string>>>>
+
+    // edge cases
+    multiArgComplex : bool -> GenericRecord<Maybe<Option<string>>> -> Async<GenericRecord<Maybe<Option<string>>>>
+
+    // long (int64) conversion
+    echoPrimitiveLong : int64 -> Async<int64>
+    echoComplexLong : GenericRecord<Int64> -> Async<GenericRecord<Int64>>
+    echoOptionalLong : Option<int64> -> Async<Option<int64>>
+    echoSingleDULong : SingleLongCase -> Async<SingleLongCase>
+    echoLongInGenericUnion : Maybe<int64> -> Async<Maybe<int64>>
+
+    echoDataTable : System.Data.DataTable -> Async<System.Data.DataTable>
+    echoDataSet : System.Data.DataSet -> Async<System.Data.DataSet>
+
+    pureTask : Task<int>
+    echoMapTask : Map<string, int> -> Task<Map<string, int>>
+}
+
+module Async =
+    let result<'a> (x: 'a) : Async<'a> =
+        async { return x }
+
+
+let simpleServer : ISimpleServer = {
+    getLength = fun input -> Async.result input.Length
+}
+
+// Async.result : 'a -> Async<'a>
+// a simple implementation, just return whatever value you get (echo the input)
+let server : IServer  = {
+    // primitive types
+    simpleUnit = fun () -> async { return 42 }
+    getLength = fun input -> Async.result input.Length
+    echoInteger = Async.result
+    echoString = Async.result
+    echoBool = Async.result
+    echoIntOption = Async.result
+    echoStringOption = Async.result
+    echoGenericUnionInt = Async.result
+    echoGenericUnionString = Async.result
+    echoSimpleUnionType = Async.result
+
+    echoRecord = Async.result
+    echoGenericRecordInt = Async.result
+    echoNestedGeneric = Async.result
+
+    echoIntList = Async.result
+    echoStringList = Async.result
+    echoBoolList = Async.result
+    echoListOfListsOfStrings = Async.result
+    echoListOfGenericRecords = Async.result
+    tuplesAndLists = fun (dict, xs) ->
+        xs
+        |> List.map (fun x -> x, x.Length)
+        |> List.append (Map.toList dict)
+        |> Map.ofList
+        |> Async.result
+
+    echoResult = Async.result
+    echoSingleCase = Async.result
+    echoBigInteger = Async.result
+    throwError = fun () -> async { return! failwith "Generating custom server error" }
+    echoMap = Async.result
+    multiArgFunc = fun str n b -> async { return str.Length + n + (if b then 1 else 0) }
+    overriddenFunction = fun str -> async { return! failwith str }
+    customStatusCode = fun () -> async {return "No content"}
+    pureAsync = async {return 42}
+    asyncNestedGeneric = async {
+        return {
+            Value = Just (Some "value")
+            OtherValue = 10
+        }
+    }
+
+    multiArgComplex = fun flag value -> Async.result value
+    echoPrimitiveLong = Async.result
+    echoComplexLong = Async.result
+    echoOptionalLong =  Async.result
+    echoSingleDULong = Async.result
+    echoLongInGenericUnion = Async.result
+    echoDataTable = Async.result
+    echoDataSet = Async.result
+}
+
+// a simple implementation, just return whatever value you get (echo the input)
+let binaryServer : IBinaryServer  = {
+    // primitive types
+    simpleUnit = fun () -> async { return 42 }
+    getLength = fun input -> Async.result input.Length
+    echoInteger = Async.result
+    echoString = Async.result
+    echoBool = Async.result
+    echoIntOption = Async.result
+    echoStringOption = Async.result
+    echoGenericUnionInt = Async.result
+    echoGenericUnionString = Async.result
+    echoSimpleUnionType = Async.result
+
+    echoRecord = Async.result
+    echoGenericRecordInt = Async.result
+    echoNestedGeneric = Async.result
+
+    echoIntList = Async.result
+    echoStringList = Async.result
+    echoBoolList = Async.result
+    echoListOfListsOfStrings = Async.result
+    echoListOfGenericRecords = Async.result
+    tuplesAndLists = fun (dict, xs) ->
+        xs
+        |> List.map (fun x -> x, x.Length)
+        |> List.append (Map.toList dict)
+        |> Map.ofList
+        |> Async.result
+
+    echoResult = Async.result
+    echoSingleCase = Async.result
+    echoBigInteger = Async.result
+    throwError = fun () -> async { return! failwith "Generating custom server error" }
+    echoMap = Async.result
+    multiArgFunc = fun str n b -> async { return str.Length + n + (if b then 1 else 0) }
+    overriddenFunction = fun str -> async { return! failwith str }
+    customStatusCode = fun () -> async {return "No content"}
+    pureAsync = async {return 42}
+    asyncNestedGeneric = async {
+        return {
+            Value = Just (Some "value")
+            OtherValue = 10
+        }
+    }
+
+    multiArgComplex = fun flag value -> Async.result value
+    echoPrimitiveLong = Async.result
+    echoComplexLong = Async.result
+    echoOptionalLong =  Async.result
+    echoSingleDULong = Async.result
+    echoLongInGenericUnion = Async.result
+    echoDataTable = Async.result
+    echoDataSet = Async.result
+
+    pureTask = Task.FromResult 42
+    echoMapTask = fun map -> Task.FromResult map
+}

--- a/Fable.Remoting.Falco.Tests/paket.references
+++ b/Fable.Remoting.Falco.Tests/paket.references
@@ -1,0 +1,6 @@
+FSharp.Core
+Newtonsoft.Json
+Expecto
+Falco
+Microsoft.AspNetCore.TestHost
+Microsoft.AspNetCore.Hosting

--- a/Fable.Remoting.Falco/Fable.Remoting.Falco.fsproj
+++ b/Fable.Remoting.Falco/Fable.Remoting.Falco.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Giraffe-Fable adapter that generates routes for shared server spec with a Fable client. Client must use Fable.Remoting.Client</Description>
+        <PackageProjectUrl>https://github.com/Zaid-Ajaj/Fable.Remoting</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/Zaid-Ajaj/Fable.Remoting.git</RepositoryUrl>
+        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Fable.Remoting/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageIconUrl></PackageIconUrl>
+        <PackageTags>fsharp;fable;remoting;rpc;webserver;falco</PackageTags>
+        <Authors>Zaid Ajaj;Diego Esmerio;David Whelan</Authors>
+        <Version>4.22.0</Version>
+        <TargetFrameworks>net9.0</TargetFrameworks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="FableFalcoAdapter.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Fable.Remoting.Server\Fable.Remoting.Server.fsproj" />
+        <ProjectReference Include="..\Fable.Remoting.MsgPack\Fable.Remoting.MsgPack.fsproj" />
+    </ItemGroup>
+
+    <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/Fable.Remoting.Falco/FableFalcoAdapter.fs
+++ b/Fable.Remoting.Falco/FableFalcoAdapter.fs
@@ -19,8 +19,7 @@ module FalcoUtils =
             do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
         }
 
-    let text (input: string) =
-        fun (ctx : HttpContext) ->
+    let text (input: string) (ctx: HttpContext) =
             task {
                 let bytes = System.Text.Encoding.UTF8.GetBytes(input)
                 do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)

--- a/Fable.Remoting.Falco/FableFalcoAdapter.fs
+++ b/Fable.Remoting.Falco/FableFalcoAdapter.fs
@@ -1,0 +1,137 @@
+﻿namespace Fable.Remoting.Falco
+
+open System
+open System.IO
+open Fable.Remoting.Server.Proxy
+open Falco
+open Fable.Remoting.Server
+open Falco.Routing
+open Microsoft.AspNetCore.Http
+open Newtonsoft.Json
+open TypeShape
+
+//Implement similar methods to the giraffe pipline. Modified to HttpHandler returns a task unit
+module FalcoUtils =
+    let writeStringAsync (input: string) (ctx: HttpContext) (logger: Option<string -> unit>) =
+        task {
+            Diagnostics.outputPhase logger input
+            let bytes = System.Text.Encoding.UTF8.GetBytes(input)
+            do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
+        }
+
+    let text (input: string) =
+        fun (ctx : HttpContext) ->
+            task {
+                let bytes = System.Text.Encoding.UTF8.GetBytes(input)
+                do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
+            }
+
+    /// Sets the content type of the Http response
+    let setContentType (contentType: string) (ctx: HttpContext) : HttpContext =
+        Response.withContentType contentType ctx
+    
+    let setResponseBody (response: obj) logger (ctx: HttpContext ) =
+            task {
+                use ms = new MemoryStream ()
+                jsonSerialize response ms
+                let responseBody = System.Text.Encoding.UTF8.GetString (ms.ToArray ())
+                do! writeStringAsync responseBody ctx logger
+            }
+
+    /// Sets the body of the response to type of JSON
+    let setBody value logger  (ctx: HttpContext)=
+                setContentType "application/json; charset=utf-8" ctx
+                |> setResponseBody value logger
+            
+
+    /// If no endpoints are found send an empty response
+    let halt : HttpHandler =
+      Response.ofEmpty
+
+    let fail (ex: exn) (routeInfo: RouteInfo<HttpContext>) (options: RemotingOptions<HttpContext, 't>) : HttpHandler =
+      let logger = options.DiagnosticsLogger
+      fun (ctx : HttpContext) ->
+        task {
+            match options.ErrorHandler with
+            | None -> return! setBody (Errors.unhandled routeInfo.methodName) logger ctx
+            | Some errorHandler ->
+                match errorHandler ex routeInfo with
+                | Ignore -> return! setBody (Errors.ignored routeInfo.methodName) logger ctx
+                | Propagate error -> return! setBody (Errors.propagated error) logger ctx
+        }
+
+    let notFound (options: RemotingOptions<HttpContext, 'impl>) : HttpHandler=
+        fun (ctx: HttpContext) -> task {
+            match ctx.Request.Method.ToUpper(), options.Docs with
+            | "GET", (Some docsUrl, Some docs) when docsUrl = ctx.Request.Path.Value ->
+                let (Documentation(docsName, docsRoutes)) = docs
+                let schema = Docs.makeDocsSchema typeof<'impl> docs options.RouteBuilder
+                let docsApp = DocsApp.embedded docsName docsUrl schema
+                return! ctx |> setContentType "text/html" |> text docsApp
+            | "OPTIONS", (Some docsUrl, Some docs)
+                when sprintf "/%s/$schema" docsUrl = ctx.Request.Path.Value
+                  || sprintf "%s/$schema" docsUrl = ctx.Request.Path.Value ->
+                let schema = Docs.makeDocsSchema typeof<'impl> docs options.RouteBuilder
+                let serializedSchema = schema.ToString(Formatting.None)
+                return! text serializedSchema ctx
+            | _ ->
+                return! halt ctx
+        }
+        
+
+    let buildFromImplementation<'impl> (implBuilder: HttpContext -> 'impl) (options: RemotingOptions<HttpContext, 'impl>) : HttpEndpoint seq=
+        let proxy = makeApiProxy options
+        let rmsManager = getRecyclableMemoryStreamManager options
+
+        let handler: HttpHandler = fun (ctx: HttpContext) -> task {
+            let isProxyHeaderPresent = ctx.Request.Headers.ContainsKey "x-remoting-proxy"
+            use output = rmsManager.GetStream "remoting-output-stream"
+
+            let props = { ImplementationBuilder = (fun () -> implBuilder ctx); EndpointName = ctx.Request.Path.Value; Input = ctx.Request.Body; IsProxyHeaderPresent = isProxyHeaderPresent;
+                HttpVerb = ctx.Request.Method; InputContentType = ctx.Request.ContentType; Output = output }
+
+            match! proxy props with
+            | Success isBinaryOutput ->
+                ctx.Response.StatusCode <- 200
+
+                if isBinaryOutput && isProxyHeaderPresent then
+                    ctx.Response.ContentType <- "application/octet-stream"
+                elif options.ResponseSerialization.IsJson then
+                    ctx.Response.ContentType <- "application/json; charset=utf-8"
+                else
+                    ctx.Response.ContentType <- "application/vnd.msgpack"
+
+                do! output.CopyToAsync ctx.Response.Body
+            | Exception (e, functionName, requestBodyText) ->
+                ctx.Response.StatusCode <- 500
+                let routeInfo = { methodName = functionName; path = ctx.Request.Path.ToString(); httpContext = ctx; requestBodyText = requestBodyText }
+                return! fail e routeInfo options ctx
+            | InvalidHttpVerb ->
+                return! halt ctx
+            | EndpointNotFound ->
+                return! notFound options ctx
+        }
+        
+        //Get a list of endpoints. Needed to construct the pattern for route matching
+        let endPoints =
+            match shapeof<'impl> with
+            | Shape.FSharpRecord (:? ShapeFSharpRecord<'impl> as shape) ->
+                shape.Fields
+                |> Array.map (fun f -> options.RouteBuilder typeof<'impl>.Name f.MemberInfo.Name)
+            | _ ->
+                failwithf "Protocol definition must be encoded as a record type. The input type '%s' was not a record." typeof<'impl>.Name
+        
+        //add document endpoint if it exists
+        let endPointsWithDoc =
+            match options.Docs with
+            | (Some docsUrl, _) -> Array.append endPoints [|docsUrl|]
+            | _ -> endPoints
+        
+        endPointsWithDoc |> Array.map (fun endPoint -> any endPoint handler) |> Seq.ofArray
+
+module Remoting =
+    let buildHttpEndpoints (options: RemotingOptions<HttpContext, 't>) : HttpEndpoint seq =
+        match options.Implementation with
+        | Empty -> []
+        | StaticValue impl -> FalcoUtils.buildFromImplementation (fun _ -> impl) options
+        | FromContext createImplementationFrom -> FalcoUtils.buildFromImplementation createImplementationFrom options

--- a/Fable.Remoting.Falco/paket.references
+++ b/Fable.Remoting.Falco/paket.references
@@ -1,0 +1,3 @@
+FSharp.Core
+Falco
+Microsoft.IO.RecyclableMemoryStream

--- a/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
+++ b/Fable.Remoting.MsgPack/Fable.Remoting.MsgPack.fsproj
@@ -25,6 +25,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Fable.Remoting.Server</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Fable.Remoting.Falco</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
    <PackageReference Update="FSharp.Core" Version="4.7.2" />

--- a/Fable.Remoting.sln
+++ b/Fable.Remoting.sln
@@ -62,6 +62,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Build", "build\Build.fsproj
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Remoting.AwsLambda", "Fable.Remoting.AwsLambda\Fable.Remoting.AwsLambda.fsproj", "{2D66CF7F-43B7-4EE5-9E0C-2DFC5315DFCF}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Remoting.Falco", "Fable.Remoting.Falco\Fable.Remoting.Falco.fsproj", "{142B0D23-DEBB-476A-A9C6-292BE40687F3}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Remoting.Falco.Tests", "Fable.Remoting.Falco.Tests\Fable.Remoting.Falco.Tests.fsproj", "{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -348,6 +352,30 @@ Global
 		{2D66CF7F-43B7-4EE5-9E0C-2DFC5315DFCF}.Release|x64.Build.0 = Release|Any CPU
 		{2D66CF7F-43B7-4EE5-9E0C-2DFC5315DFCF}.Release|x86.ActiveCfg = Release|Any CPU
 		{2D66CF7F-43B7-4EE5-9E0C-2DFC5315DFCF}.Release|x86.Build.0 = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|x64.Build.0 = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{142B0D23-DEBB-476A-A9C6-292BE40687F3}.Release|x86.Build.0 = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|x64.Build.0 = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{F29937CF-8C1C-4154-93BA-FCEB5FF4C7E5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -44,6 +44,7 @@ let MsgPackTestsDll = testDll "MsgPack"
 let ServerTestsDll = testDll "Server"
 let SuaveTestDll = testDll "Suave"
 let GiraffeTestDll = testDll "Giraffe"
+let FalcoTestDll = testDll "Falco"
 
 let dotnet = "dotnet"
 
@@ -68,6 +69,7 @@ let Server = getPath "Server"
 let Suave = getPath "Suave"
 let Giraffe = getPath "Giraffe"
 let GiraffeNET5 = getPath "GiraffeNET5"
+let Falco = getPath "Falco"
 let DotnetClient = getPath "DotnetClient"
 let AspNetCore = getPath "AspNetCore"
 let MsgPack = getPath "MsgPack"
@@ -105,6 +107,7 @@ createTarget "PublishServer" (publish Server)
 createTarget "PublishDotnetClient" (publish DotnetClient)
 createTarget "PublishSuave" (publish Suave)
 createTarget "PublishGiraffeNET5" (publish GiraffeNET5)
+createTarget "PublishFalco" (publish Falco)
 createTarget "PublishAspnetCore" (publish AspNetCore)
 createTarget "PublishMsgPack" (publish MsgPack)
 createTarget "PublishAwsLambda" (publish AwsLambda)
@@ -116,6 +119,7 @@ createTarget "PublishMsgPackDownstream" (fun ctx ->
     publish Server ctx
     publish Suave ctx
     publish GiraffeNET5 ctx
+    publish Falco ctx
     publish AspNetCore ctx
     publish DotnetClient ctx
     publish AzureFunctionsWorker ctx
@@ -127,6 +131,7 @@ createTarget "PublishJsonDownstream" (fun ctx ->
     publish Server ctx
     publish Suave ctx
     publish GiraffeNET5 ctx
+    publish Falco ctx
     publish AspNetCore ctx
     publish DotnetClient ctx
     publish AzureFunctionsWorker ctx
@@ -137,6 +142,7 @@ createTarget "PublishServerDownstream" (fun ctx ->
     publish Server ctx
     publish Suave ctx
     publish GiraffeNET5 ctx
+    publish Falco ctx
     publish AspNetCore ctx
     publish AzureFunctionsWorker ctx
 )
@@ -162,6 +168,13 @@ createTarget "BuildGiraffeTests" <| fun _ ->
     clean (getPath "Giraffe")
     clean (getPath "Giraffe.Tests")
     let path = getPath "Giraffe.Tests"
+    run path "dotnet" "restore --no-cache"
+    run path "dotnet" "build -c Debug"
+
+createTarget "BuildFalcoTests" <| fun _ ->
+    clean (getPath "Falco")
+    clean (getPath "Falco.Tests")
+    let path = getPath "Falco.Tests"
     run path "dotnet" "restore --no-cache"
     run path "dotnet" "build -c Debug"
 
@@ -207,6 +220,18 @@ createTarget "BuildRunGiraffeTests" <| fun _ ->
 
 createTarget "RunGiraffeTests" <| fun _ ->
     run cwd "dotnet" GiraffeTestDll
+
+createTarget "RestoreBuildRunFalcoTests" <| fun _ ->
+    run cwd "dotnet"  ("restore " + proj "Falco.Tests")
+    run cwd "dotnet" ("build " + proj "Falco.Tests" + " --configuration=Release")
+    run cwd "dotnet" FalcoTestDll
+
+createTarget "BuildRunFalcoTests" <| fun _ ->
+    run cwd "dotnet" ("build " + proj "Falco.Tests" + " --configuration=Release")
+    run cwd "dotnet" FalcoTestDll
+
+createTarget "RunFalcoTests" <| fun _ ->
+    run cwd "dotnet" FalcoTestDll
 
 createTarget "BuildDocs" <| fun _ ->
     run docs "npm" "install"
@@ -269,6 +294,9 @@ createTarget "BuildRunAllTests" <| fun _ ->
     // Giraffe
     run cwd "dotnet" ("build " + proj "Giraffe.Tests" + " --configuration=Release")
     run cwd "dotnet" GiraffeTestDll
+    // Falco
+    run cwd "dotnet" ("build " + proj "Falco.Tests" + " --configuration=Release")
+    run cwd "dotnet" FalcoTestDll
 
 let runHeadlessBrowserTests() =
     run clientUITests "dotnet" "restore --no-cache"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -16,6 +16,7 @@ nuget NUnit >= 3.12
 nuget PuppeteerSharp >= 7.1
 nuget Suave >= 2.6.0
 nuget Giraffe >= 4.1
+nuget Falco >= 5.1.0
 nuget System.Formats.Asn1 >= 6.0.1
 nuget System.Security.Cryptography.Pkcs >= 6.0.4
 

--- a/paket.lock
+++ b/paket.lock
@@ -22,6 +22,11 @@ NUGET
     Expecto (9.0.2)
       FSharp.Core (>= 4.6) - restriction: || (>= net461) (>= netstandard2.0)
       Mono.Cecil (>= 0.11.2) - restriction: || (>= net461) (>= netstandard2.0)
+    Falco (5.1)
+      Falco.Markup (>= 1.4) - restriction: >= net8.0
+      FSharp.Core (>= 6.0) - restriction: >= net8.0
+    Falco.Markup (1.4) - restriction: >= net8.0
+      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
     FSharp.Core (6.0)
     Giraffe (4.1)
       FSharp.Core (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
@@ -60,7 +65,7 @@ NUGET
       Microsoft.Bcl.AsyncInterfaces (>= 9.0.3) - restriction: || (>= net462) (&& (< net9.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
       Microsoft.Extensions.Features (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       System.IO.Pipelines (>= 9.0.3) - restriction: || (>= net462) (&& (< net9.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
-    Microsoft.AspNetCore.Cryptography.Internal (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Cryptography.Internal (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
     Microsoft.AspNetCore.DataProtection (6.0.35) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
       Microsoft.AspNetCore.Cryptography.Internal (>= 6.0.35) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 6.0.35) - restriction: || (>= net461) (>= netstandard2.0)
@@ -72,7 +77,7 @@ NUGET
       System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: >= net461
       System.Security.Cryptography.Xml (>= 6.0.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.Security.Principal.Windows (>= 5.0) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
-    Microsoft.AspNetCore.DataProtection.Abstractions (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (>= net462) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.DataProtection.Abstractions (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
     Microsoft.AspNetCore.Diagnostics (2.3) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.3) - restriction: >= netstandard2.0
@@ -120,7 +125,7 @@ NUGET
       Microsoft.Extensions.FileProviders.Abstractions (>= 8.0) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.3) - restriction: >= netstandard2.0
       System.Buffers (>= 4.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (5.0.17) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Features (5.0.17) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
       Microsoft.Extensions.Primitives (>= 5.0.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.IO.Pipelines (>= 5.0.2) - restriction: || (>= net461) (>= netstandard2.0)
     Microsoft.AspNetCore.Metadata (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (>= net462) (&& (< netcoreapp3.0) (>= netstandard2.0))
@@ -283,7 +288,7 @@ NUGET
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.Logging (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
-    Microsoft.Extensions.ObjectPool (9.0.3) - restriction: >= netstandard2.0
+    Microsoft.Extensions.ObjectPool (9.0.3) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
     Microsoft.Extensions.Options (9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.Primitives (>= 9.0.3) - restriction: || (>= net462) (>= netstandard2.0)


### PR DESCRIPTION
Pull request involving issue #312

This pull request adds an adapter for the falco framework. It converts the fable remoting logic into a sequence of falco HttpEndpoints used by the framework. Multiple fable remoting apps can be used by appending the HttpEndpoint sequences together. The pull request also includes tests that are basically a copy of the middleware tests but adapted to the falco framework.

The only thing missing is documentation on how to use the adapter. Where is the correct place to update the documentation? I am unfamiliar with the doc vs documentation and how it all ties together